### PR TITLE
Speedup travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
     - rm -rf /tmp/shopware/engine/Shopware/Plugins/Default/Backend/SwagBepado
     - cd ..
     - cd /tmp/shopware
-    - ant -f build/build.xml -Ddb.user=travis -Ddb.host=127.0.0.1 -Ddb.name=shopware build-continuous
+    - ant -f build/build.xml -Ddb.user=travis -Ddb.host=127.0.0.1 -Ddb.name=shopware build-unit
     - mv /home/travis/build/shopware/SwagBepado /tmp/shopware/engine/Shopware/Plugins/Local/Backend
     - cd /tmp/shopware
     - ls engine/Shopware/Plugins/Local/Backend


### PR DESCRIPTION
Do not start shopware`s own unit testsuite to speedup the build process
