### PR TITLE
Remove deprecated function calls

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -132,7 +132,7 @@ final class Shopware_Plugins_Backend_SwagConnect_Bootstrap extends Shopware_Comp
      */
     public function doSetup($fullSetup = true)
     {
-        if (!$this->assertMinimumVersion('5.2.0')) {
+        if (!$this->assertMinimumVersion('5.0.0')) {
             throw new \RuntimeException('Shopware version 4.1.0 or later is required.');
         };
 

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -132,7 +132,7 @@ final class Shopware_Plugins_Backend_SwagConnect_Bootstrap extends Shopware_Comp
      */
     public function doSetup($fullSetup = true)
     {
-        if (!$this->assertVersionGreaterThen('4.1.0')) {
+        if (!$this->assertMinimumVersion('5.2.0')) {
             throw new \RuntimeException('Shopware version 4.1.0 or later is required.');
         };
 

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -132,13 +132,17 @@ final class Shopware_Plugins_Backend_SwagConnect_Bootstrap extends Shopware_Comp
      */
     public function doSetup($fullSetup = true)
     {
-        if (!$this->assertMinimumVersion('5.0.0')) {
-            throw new \RuntimeException('Shopware version 4.1.0 or later is required.');
+        if (!$this->assertMinimumVersion('5.2.0')) {
+            throw new \RuntimeException('Shopware version 5.2.0 or later is required.');
         };
 
         $this->registerMyLibrary();
 
-        $setup = new Setup($this, $this->assertMinimumVersion('5.2.6'));
+        $setup = new Setup(
+            $this,
+            $this->assertMinimumVersion('5.2.6'),
+            $this->get('shopware_attribute.crud_service')
+        );
         $setup->run($fullSetup);
     }
 

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -167,7 +167,11 @@ final class Shopware_Plugins_Backend_SwagConnect_Bootstrap extends Shopware_Comp
     {
         $this->registerMyLibrary();
 
-        $uninstall = new Uninstall($this, $this->assertMinimumVersion('5.2.6'));
+        $uninstall = new Uninstall(
+            $this,
+            $this->assertMinimumVersion('5.2.6'),
+            $this->get('shopware_attribute.crud_service')
+        );
         return $uninstall->run();
     }
 

--- a/Bootstrap/Setup.php
+++ b/Bootstrap/Setup.php
@@ -2,6 +2,8 @@
 
 namespace ShopwarePlugins\Connect\Bootstrap;
 
+use Shopware\Bundle\AttributeBundle\Service\CrudService;
+use Shopware\Bundle\AttributeBundle\Service\DataPersister;
 use Shopware\Models\Article\Element;
 use Shopware\Models\Customer\Group;
 
@@ -14,13 +16,29 @@ use Shopware\Models\Customer\Group;
  */
 class Setup
 {
+    const ATTRIBUTE_PREFIX = 'connect_';
+
     protected $bootstrap;
     protected $shopware526installed;
 
-    public function __construct(\Shopware_Plugins_Backend_SwagConnect_Bootstrap $bootstrap, $shopware526installed)
-    {
+    /**
+     * @var CrudService
+     */
+    private $crudService;
+
+    /**
+     * @param \Shopware_Plugins_Backend_SwagConnect_Bootstrap $bootstrap
+     * @param $shopware526installed
+     * @param CrudService $crudService
+     */
+    public function __construct(
+        \Shopware_Plugins_Backend_SwagConnect_Bootstrap $bootstrap,
+        $shopware526installed,
+        CrudService $crudService
+    ) {
         $this->bootstrap = $bootstrap;
         $this->shopware526installed = $shopware526installed;
+        $this->crudService = $crudService;
     }
 
     public function run($fullSetup)
@@ -401,124 +419,113 @@ class Setup
      */
     private function createMyAttributes()
     {
-        /** @var \Shopware\Components\Model\ModelManager $modelManager */
-        $modelManager =Shopware()->Models();
-
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_order_attributes',
-            'connect', 'shop_id',
+            self::ATTRIBUTE_PREFIX . 'shop_id',
             'int(11)'
         );
-        $modelManager->addAttribute(
+        
+        $this->crudService->update(
             's_order_attributes',
-            'connect', 'order_id',
+            'shop_id',
             'int(11)'
         );
 
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_categories_attributes',
-            'connect', 'import_mapping',
+            self::ATTRIBUTE_PREFIX . 'import_mapping',
             'text'
         );
 
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_categories_attributes',
-            'connect', 'export_mapping',
+            self::ATTRIBUTE_PREFIX . 'export_mapping',
             'text'
         );
 
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_categories_attributes',
-            'connect', 'imported',
+            self::ATTRIBUTE_PREFIX . 'imported',
             'text'
         );
 
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_media_attributes',
-            'connect', 'hash',
+            self::ATTRIBUTE_PREFIX . 'hash',
             'varchar(255)'
         );
 
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_premium_dispatch_attributes',
-            'connect', 'allowed',
+            self::ATTRIBUTE_PREFIX . 'allowed',
             'int(1)',
-            true,
+            [],
+            null,
+            false,
             1
         );
 
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_articles_attributes',
-            'connect', 'product_description',
+            self::ATTRIBUTE_PREFIX . 'product_description',
             'text'
         );
 
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_articles_prices_attributes',
-            'connect', 'price',
+            self::ATTRIBUTE_PREFIX . 'price',
             'double',
-            true,
+            [],
+            null,
+            false,
             0
         );
 
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_core_customergroups_attributes',
-            'connect', 'group',
+            self::ATTRIBUTE_PREFIX . 'group',
             'int(1)'
         );
 
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_articles_attributes',
-            'connect', 'article_shipping',
+            self::ATTRIBUTE_PREFIX . 'article_shipping',
             'varchar(1000)'
         );
 
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_articles_attributes',
-            'connect', 'reference',
+            self::ATTRIBUTE_PREFIX . 'reference',
             'varchar(500)'
         );
 
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_premium_dispatch_attributes',
-            'connect', 'allowed',
+            self::ATTRIBUTE_PREFIX . 'allowed',
             'int(1)',
-            true,
+            [],
+            null,
+            false,
             1
         );
 
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_categories_attributes',
-            'connect', 'imported_category',
-            'int(1)',
-            true
+            self::ATTRIBUTE_PREFIX . 'imported_category',
+            'int(1)'
         );
 
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_articles_attributes',
-            'connect', 'mapped_category',
-            'int(1)',
-            true
+            self::ATTRIBUTE_PREFIX . 'mapped_category',
+            'int(1)'
         );
 
-        $modelManager->addAttribute(
+        $this->crudService->update(
             's_articles_attributes',
-            'connect', 'remote_unit',
-            'varchar(32)',
-            true
+            self::ATTRIBUTE_PREFIX . 'remote_unit',
+            'varchar(32)'
         );
-
-        $modelManager->generateAttributeModels(array(
-            's_articles_attributes',
-            's_order_attributes',
-            's_core_customergroups_attributes',
-            's_articles_prices_attributes',
-            's_premium_dispatch_attributes',
-            's_categories_attributes',
-            's_order_details_attributes',
-            's_order_basket_attributes',
-            's_media_attributes'
-        ));
     }
 
 

--- a/Bootstrap/Setup.php
+++ b/Bootstrap/Setup.php
@@ -434,7 +434,7 @@ class Setup
         
         $this->crudService->update(
             's_order_attributes',
-            'shop_id',
+            self::ATTRIBUTE_PREFIX . 'order_id',
             'int(11)'
         );
 

--- a/Bootstrap/Setup.php
+++ b/Bootstrap/Setup.php
@@ -18,7 +18,14 @@ class Setup
 {
     const ATTRIBUTE_PREFIX = 'connect_';
 
+    /**
+     * @var \Shopware_Plugins_Backend_SwagConnect_Bootstrap
+     */
     protected $bootstrap;
+
+    /**
+     * @var bool
+     */
     protected $shopware526installed;
 
     /**
@@ -28,7 +35,7 @@ class Setup
 
     /**
      * @param \Shopware_Plugins_Backend_SwagConnect_Bootstrap $bootstrap
-     * @param $shopware526installed
+     * @param bool $shopware526installed
      * @param CrudService $crudService
      */
     public function __construct(
@@ -726,19 +733,15 @@ class Setup
      */
     public function generateConnectPaymentAttribute()
     {
-        Shopware()->Models()->addAttribute(
+        $this->crudService->update(
             's_core_paymentmeans_attributes',
-            'connect', 'is_allowed',
+            self::ATTRIBUTE_PREFIX . 'is_allowed',
             'int(1)',
-            true,
+            [],
+            null,
+            false,
             1
         );
-
-        Shopware()->Models()->generateAttributeModels(array(
-            's_core_paymentmeans_attributes'
-        ));
-
-        Shopware()->Models()->regenerateProxies();
     }
 
     public function populateConnectPaymentAttribute()

--- a/Bootstrap/Uninstall.php
+++ b/Bootstrap/Uninstall.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace ShopwarePlugins\Connect\Bootstrap;
+use Shopware\Bundle\AttributeBundle\Service\CrudService;
 
 /**
  * Uninstaller of the plugin.
@@ -15,10 +16,24 @@ class Uninstall
     protected $bootstrap;
     protected $shopware526installed;
 
-    public function __construct(\Shopware_Plugins_Backend_SwagConnect_Bootstrap $bootstrap, $shopware526installed)
-    {
+    /**
+     * @var CrudService
+     */
+    private $crudService;
+
+    /**
+     * @param \Shopware_Plugins_Backend_SwagConnect_Bootstrap $bootstrap
+     * @param $shopware526installed
+     * @param CrudService $crudService
+     */
+    public function __construct(
+        \Shopware_Plugins_Backend_SwagConnect_Bootstrap $bootstrap,
+        $shopware526installed,
+        CrudService $crudService
+    ) {
         $this->bootstrap = $bootstrap;
         $this->shopware526installed = $shopware526installed;
+        $this->crudService = $crudService;
     }
 
     public function run()
@@ -38,54 +53,40 @@ class Uninstall
      */
     public function removeMyAttributes()
     {
-        /** @var \Shopware\Components\Model\ModelManager $modelManager */
-        $modelManager = Shopware()->Models();
+        $this->crudService->delete(
+            's_order_attributes',
+            Setup::ATTRIBUTE_PREFIX . 'shop_id'
+        );
 
-        try {
-            $modelManager->removeAttribute(
-                's_order_attributes',
-                'connect', 'shop_id'
-            );
-            $modelManager->removeAttribute(
-                's_order_attributes',
-                'connect', 'order_id'
-            );
+        $this->crudService->delete(
+            's_order_attributes',
+            Setup::ATTRIBUTE_PREFIX . 'order_id'
+        );
 
-            $modelManager->removeAttribute(
-                's_categories_attributes',
-                'connect', 'import_mapping'
-            );
+        $this->crudService->delete(
+            's_categories_attributes',
+            Setup::ATTRIBUTE_PREFIX . 'import_mapping'
+        );
 
-            $modelManager->removeAttribute(
-                's_categories_attributes',
-                'connect', 'export_mapping'
-            );
+        $this->crudService->delete(
+            's_categories_attributes',
+            Setup::ATTRIBUTE_PREFIX . 'export_mapping'
+        );
 
-            $modelManager->removeAttribute(
-                's_categories_attributes',
-                'connect', 'imported'
-            );
+        $this->crudService->delete(
+            's_categories_attributes',
+            Setup::ATTRIBUTE_PREFIX . 'imported'
+        );
 
-            $modelManager->removeAttribute(
-                's_premium_dispatch_attributes',
-                'connect', 'allowed'
-            );
+        $this->crudService->delete(
+            's_premium_dispatch_attributes',
+            Setup::ATTRIBUTE_PREFIX . 'allowed'
+        );
 
-            $modelManager->removeAttribute(
-                's_media_attributes',
-                'connect', 'hash'
-            );
-
-            $modelManager->generateAttributeModels(array(
-                's_premium_dispatch_attributes',
-                's_categories_attributes',
-                's_order_details_attributes',
-                's_order_basket_attributes',
-                's_media_attributes'
-            ));
-        } catch (\Exception $e) {
-        }
-
+        $this->crudService->delete(
+            's_media_attributes',
+            Setup::ATTRIBUTE_PREFIX . 'hash'
+        );
     }
 
     /**

--- a/Bootstrap/Uninstall.php
+++ b/Bootstrap/Uninstall.php
@@ -13,7 +13,14 @@ use Shopware\Bundle\AttributeBundle\Service\CrudService;
  */
 class Uninstall
 {
+    /**
+     * @var \Shopware_Plugins_Backend_SwagConnect_Bootstrap
+     */
     protected $bootstrap;
+
+    /**
+     * @var bool
+     */
     protected $shopware526installed;
 
     /**
@@ -23,7 +30,7 @@ class Uninstall
 
     /**
      * @param \Shopware_Plugins_Backend_SwagConnect_Bootstrap $bootstrap
-     * @param $shopware526installed
+     * @param boolean $shopware526installed
      * @param CrudService $crudService
      */
     public function __construct(

--- a/Components/ConnectFactory.php
+++ b/Components/ConnectFactory.php
@@ -64,7 +64,7 @@ class ConnectFactory
     public function getSDK()
     {
         if(!$this->sdk) {
-            $this->sdk = Shopware()->Bootstrap()->getResource('ConnectSDK');
+            $this->sdk = Shopware()->Container()->get('ConnectSDK');
         }
 
         return $this->sdk;

--- a/Components/ProductFromShop.php
+++ b/Components/ProductFromShop.php
@@ -399,7 +399,7 @@ class ProductFromShop implements ProductFromShopBase
         if (!$shop) {
             return new Shipping(array('isShippable' => false));
         }
-        $shop->registerResources(Shopware()->Bootstrap());
+        $shop->registerResources();
 
         /** @var /Enlight_Components_Session_Namespace $session */
         $session = Shopware()->Session();

--- a/Components/Utils/OrderPaymentMapper.php
+++ b/Components/Utils/OrderPaymentMapper.php
@@ -31,7 +31,7 @@ class OrderPaymentMapper
                 'paypal' => OrderStruct::PAYMENT_PROVIDER,
             );
 
-            $this->mapping = Enlight()->Events()->filter('Connect_OrderStatus_Mapping', $this->mapping);
+            $this->mapping = Shopware()->Events()->filter('Connect_OrderStatus_Mapping', $this->mapping);
         }
 
         return $this->mapping;

--- a/Components/Utils/OrderPaymentStatusMapper.php
+++ b/Components/Utils/OrderPaymentStatusMapper.php
@@ -40,7 +40,7 @@ class OrderPaymentStatusMapper
                 'sc_error' => PaymentStatus::PAYMENT_ERROR,
             );
 
-            $this->mapping = Enlight()->Events()->filter('Connect_OrderPaymentStatus_Mapping', $this->mapping);
+            $this->mapping = Shopware()->Events()->filter('Connect_OrderPaymentStatus_Mapping', $this->mapping);
         }
 
         return $this->mapping;

--- a/Components/Utils/OrderStatusMapper.php
+++ b/Components/Utils/OrderStatusMapper.php
@@ -38,7 +38,7 @@ class OrderStatusMapper
                 '4' => OrderStatusStruct::STATE_ERROR, // 4 = Storno / Rejected
             );
 
-            $this->mapping = Enlight()->Events()->filter('Connect_OrderStatus_Mapping', $this->mapping);
+            $this->mapping = Shopware()->Events()->filter('Connect_OrderStatus_Mapping', $this->mapping);
         }
 
         return $this->mapping;

--- a/Controllers/Backend/ConnectBaseController.php
+++ b/Controllers/Backend/ConnectBaseController.php
@@ -89,7 +89,7 @@ class ConnectBaseController extends \Shopware_Controllers_Backend_ExtJs
     public function getSDK()
     {
         if ($this->sdk === null) {
-            $this->sdk = Shopware()->Bootstrap()->getResource('ConnectSDK');
+            $this->sdk = Shopware()->Container()->get('ConnectSDK');
         }
 
         return $this->sdk;
@@ -494,7 +494,7 @@ class ConnectBaseController extends \Shopware_Controllers_Backend_ExtJs
         $marketplaceNetworkUrl = $this->getConfigComponent()->getConfig('marketplaceNetworkUrl', Connect::MARKETPLACE_SOCIAL_NETWORK_URL);
         $defaultMarketplace = $this->getConfigComponent()->getConfig('isDefault', true);
         $isFixedPriceAllowed = 0;
-        $priceType = Shopware()->Bootstrap()->getResource('ConnectSDK')->getPriceType();
+        $priceType = Shopware()->Container()->get('ConnectSDK')->getPriceType();
         if ($priceType === SDK::PRICE_TYPE_BOTH ||
             $priceType === SDK::PRICE_TYPE_RETAIL) {
             $isFixedPriceAllowed = 1;

--- a/Controllers/Backend/ConnectConfig.php
+++ b/Controllers/Backend/ConnectConfig.php
@@ -443,7 +443,7 @@ class Shopware_Controllers_Backend_ConnectConfig extends Shopware_Controllers_Ba
      */
     public function getSDK()
     {
-        return Shopware()->Bootstrap()->getResource('ConnectSDK');
+        return Shopware()->Container()->get('ConnectSDK');
     }
 
     /**

--- a/Controllers/Backend/ConnectGatewayBaseController.php
+++ b/Controllers/Backend/ConnectGatewayBaseController.php
@@ -60,7 +60,7 @@ class ConnectGatewayBaseController extends \Enlight_Controller_Action
      */
     public function getSDK()
     {
-        return Shopware()->Bootstrap()->getResource('ConnectSDK');
+        return Shopware()->Container()->get('ConnectSDK');
     }
 
     public function getConfigComponent()

--- a/Controllers/Frontend/Connect.php
+++ b/Controllers/Frontend/Connect.php
@@ -35,6 +35,6 @@ class Shopware_Controllers_Frontend_Connect extends Enlight_Controller_Action
      */
     public function getSDK()
     {
-        return Shopware()->Bootstrap()->getResource('ConnectSDK');
+        return Shopware()->Container()->get('ConnectSDK');
     }
 }

--- a/Controllers/Frontend/ConnectProductGateway.php
+++ b/Controllers/Frontend/ConnectProductGateway.php
@@ -134,7 +134,7 @@ class Shopware_Controllers_Frontend_ConnectProductGateway extends Enlight_Contro
         if (!$shop) {
             $this->forward('index', 'index');
         }
-        $shop->registerResources(Shopware()->Bootstrap());
+        $shop->registerResources();
 
         $this->Response()->setCookie('shop', $shopId, 0, $shop->getBasePath());
 

--- a/Controllers/Widgets/Connect.php
+++ b/Controllers/Widgets/Connect.php
@@ -35,6 +35,6 @@ class Shopware_Controllers_Widgets_Connect extends Enlight_Controller_Action
      */
     public function getSDK()
     {
-        return Shopware()->Bootstrap()->getResource('ConnectSDK');
+        return Shopware()->Container()->get('ConnectSDK');
     }
 }

--- a/Subscribers/Connect.php
+++ b/Subscribers/Connect.php
@@ -100,7 +100,7 @@ class Connect extends BaseSubscriber
         $view->marketplaceIcon = $marketplaceIcon;
         $view->defaultMarketplace = $this->getConfigComponent()->getConfig('isDefault', true);
         $isFixedPriceAllowed = 0;
-        $priceType = Shopware()->Bootstrap()->getResource('ConnectSDK')->getPriceType();
+        $priceType = Shopware()->Container()->get('ConnectSDK')->getPriceType();
         if ($priceType === SDK::PRICE_TYPE_BOTH ||
             $priceType === SDK::PRICE_TYPE_RETAIL) {
             $isFixedPriceAllowed = 1;

--- a/Tests/Shopware/Connect/Bootstrap.php
+++ b/Tests/Shopware/Connect/Bootstrap.php
@@ -9,4 +9,4 @@ if (file_exists('./../../../../../../tests/Shopware/TestHelper.php')) {
 }
 Shopware()->Loader()->registerNamespace('Tests\ShopwarePlugins\Connect', __DIR__  . '/');
 
-Shopware()->Bootstrap()->getResource('ConnectSDK');
+Shopware()->Container()->get('ConnectSDK');

--- a/Tests/Shopware/Connect/Component/ImportServiceTest.php
+++ b/Tests/Shopware/Connect/Component/ImportServiceTest.php
@@ -54,7 +54,7 @@ class ImportServiceTest extends ConnectTestHelper
         $this->importService = new ImportService(
             $this->manager,
             Shopware()->Container()->get('multi_edit.product'),
-            $this->remoteCategoryRepository,
+            $this->categoryRepository,
             $this->articleRepository,
             $this->remoteCategoryRepository,
             $this->manager->getRepository('Shopware\CustomModels\Connect\ProductToRemoteCategory'),

--- a/Tests/Shopware/Connect/ConnectTestHelper.php
+++ b/Tests/Shopware/Connect/ConnectTestHelper.php
@@ -30,7 +30,7 @@ class ConnectTestHelper extends \Enlight_Components_Test_Plugin_TestCase
      */
     public function getSDK()
     {
-        return Shopware()->Bootstrap()->getResource('ConnectSDK');
+        return Shopware()->Container()->get('ConnectSDK');
     }
 
     /**
@@ -122,7 +122,7 @@ class ConnectTestHelper extends \Enlight_Components_Test_Plugin_TestCase
 
     public static function dispatchRpcCall($service, $command, array $args)
     {
-        $sdk = Shopware()->Bootstrap()->getResource('ConnectSDK');
+        $sdk = Shopware()->Container()->get('ConnectSDK');
         $refl = new \ReflectionObject($sdk);
         $property = $refl->getProperty('dependencies');
         $property->setAccessible(true);

--- a/Tests/Shopware/Connect/HelperTest.php
+++ b/Tests/Shopware/Connect/HelperTest.php
@@ -35,7 +35,7 @@ class HelperTest extends ConnectTestHelper
         /** @var \Shopware\Models\Shop\Repository $repo */
         $repo = Shopware()->Models()->getRepository('Shopware\Models\Shop\Shop');
         $shop = $repo->getActiveDefault();
-        $shop->registerResources(Shopware()->Bootstrap());
+        $shop->registerResources();
 
         // todo@sb: Fix unit test
 //        $id = $this->getConnectProductArticleId();

--- a/plugin.json
+++ b/plugin.json
@@ -17,7 +17,7 @@
         }
     },
     "compatibility": {
-        "minimumVersion": "5.0.0",
+        "minimumVersion": "5.2.0",
         "blacklist": []
     }
 }


### PR DESCRIPTION
Removed method calls on deprecated methods.
- Set minimum version to `5.2.0`
- Usage of the new attribute system in `Setup.php` & `Uninstall.php`
- Removed `Shopware()->Bootstrap` calls
- Removed `Enlight()` calls with `Shopware()`

**Todo:**
- `engine/Shopware/Plugins/Local/Backend/SwagConnect/Bootstrap/Setup.php:610`
