### PR TITLE
[CON-4170] Don't auto-login the user, it will create problems with SBP

### DIFF
--- a/Controllers/Backend/ConnectBaseController.php
+++ b/Controllers/Backend/ConnectBaseController.php
@@ -756,14 +756,7 @@ class ConnectBaseController extends \Shopware_Controllers_Backend_ExtJs
      */
     public function autoLoginAction()
     {
-        $response = $this->getSnHttpClient()->sendRequestToConnect(array(), 'account/generate-token');
-
-        $responseBody = json_decode($response->getBody());
-        if (!$responseBody->success) {
-            throw new \RuntimeException($responseBody->message);
-        }
-
-        return $this->redirect('http://' . $this->getHost() . '/login/' . $responseBody->loginToken);
+        return $this->redirect('http://' . $this->getHost() . '/login');
     }
 
     /**


### PR DESCRIPTION
Please also check https://github.com/shopware/Mosaic/pull/1807

This change is necessary, as the auto-login does not create a proper SBP token. Right now the logout does not work properly, otherwise the users who are coming from Shopware would always get a nasty error message when they try to login, and they have to login manually.