### PR TITLE
CON-4591 Improved property creation

### DIFF
--- a/Components/ProductToShop.php
+++ b/Components/ProductToShop.php
@@ -519,7 +519,7 @@ class ProductToShop implements ProductToShopBase
 
         foreach ($product->properties as $property) {
             $option = $optionRepo->findOneBy(['name' => $property->option]);
-
+            $optionExists = $option instanceof PropertyOption;
             if (!$option) {
                 $option = new PropertyOption();
                 $option->setName($property->option);
@@ -534,9 +534,7 @@ class ProductToShop implements ProductToShopBase
                 $this->manager->flush($option);
             }
 
-            $value = $valueRepo->findOneBy(['optionId' => $option->getId(), 'value' => $property->value]);
-
-            if (!$value) {
+            if (!$optionExists || !$value = $valueRepo->findOneBy(['option' => $option, 'value' => $property->value])) {
                 $value = new PropertyValue($option, $property->value);
                 $value->setPosition($property->valuePosition);
 

--- a/Components/ProductToShop.php
+++ b/Components/ProductToShop.php
@@ -511,9 +511,13 @@ class ProductToShop implements ProductToShopBase
             $this->manager->flush();
         }
 
+        $propertyValues = $article->getPropertyValues();
+        $propertyValues->clear();
+        $this->manager->persist($article);
+        $this->manager->flush();
+
         $article->setPropertyGroup($group);
 
-        $valueCollection = new ArrayCollection();
         $optionRepo = $this->manager->getRepository(PropertyOption::class);
         $valueRepo = $this->manager->getRepository(PropertyValue::class);
 
@@ -546,7 +550,10 @@ class ProductToShop implements ProductToShopBase
                 $this->manager->persist($value);
             }
 
-            $valueCollection->add($value);
+            if (!$propertyValues->contains($value)) {
+                //add only new values
+                $propertyValues->add($value);
+            }
 
             $filters = [
                 ['property' => "options.name", 'expression' => '=', 'value' => $property->option],
@@ -563,7 +570,7 @@ class ProductToShop implements ProductToShopBase
             }
         }
 
-        $article->setPropertyValues($valueCollection);
+        $article->setPropertyValues($propertyValues);
 
         $this->manager->persist($article);
         $this->manager->flush();


### PR DESCRIPTION
Didn't find a way how to simulate described bug, but I made some improvements and probably this problem won't occur in the future.

**First**: when option doesn't exist in merchant shop, PropertyValue doesn't exist as well. So we don't need to call DB in this case. 

**Second**: I've changed ```$valueRepo->findOneBy(['optionId' => $option->getId(), 'value' => $property->value]);``` to ```$valueRepo->findOneBy(['option' => $option, 'value' => $property->value])```, because there isn't setter and getter for optionId. It's just e property mapped to column "optionID". this column is also mapped to property "option" in this class. It has many to one connection. So I prefer to use ```PropertyValue::option``` instead of ```PropertyValue::optionID```.