### PR TITLE
NTR - Fix connect:endpoint:set command

### DIFF
--- a/Commands/ApiEndpointCommand.php
+++ b/Commands/ApiEndpointCommand.php
@@ -35,6 +35,9 @@ class ApiEndpointCommand extends ShopwareCommand
         $apiEndpoint = $input->getArgument('api-endpoint');
 
         $host = parse_url($apiEndpoint, PHP_URL_HOST);
+        if (!$host) {
+            $host = $apiEndpoint;
+        }
 
         $configWriter->save('connectDebugHost', $host);
         $symfonyStyle->success('Endpoint was updated successfully to ' . $host);

--- a/Tests/Shopware/Connect/Command/ApiEndpointCommandTest.php
+++ b/Tests/Shopware/Connect/Command/ApiEndpointCommandTest.php
@@ -11,6 +11,7 @@ class ApiEndpointCommandTest extends ConnectTestHelper
     {
         $result = $this->runCommand('connect:endpoint:set sn.connect.local');
         $this->assertContains('Endpoint was updated', $result[1]);
+        $this->assertContains('sn.connect.local', $result[1]);
     }
 
     public function testShouldParseUrlWithoutProtocol()


### PR DESCRIPTION
The problem was that the `parse_url` did not worked well if the host only contained `sn.connect.local`. 