### PR TITLE
Fix product stream repository constructor for shopware 53

### DIFF
--- a/Components/ProductStream/ProductStreamRepository.php
+++ b/Components/ProductStream/ProductStreamRepository.php
@@ -2,6 +2,7 @@
 
 namespace ShopwarePlugins\Connect\Components\ProductStream;
 
+use Shopware\Components\LogawareReflectionHelper;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Components\ProductStream\Repository;
 use Doctrine\ORM\Query\Expr\Join;
@@ -22,9 +23,9 @@ class ProductStreamRepository extends Repository
      * ProductStreamRepository constructor.
      * @param ModelManager $manager
      */
-    public function __construct(ModelManager $manager)
+    public function __construct(ModelManager $manager, LogawareReflectionHelper $reflectionHelper)
     {
-        parent::__construct($manager->getConnection());
+        parent::__construct($manager->getConnection(), $reflectionHelper);
         $this->manager = $manager;
     }
 

--- a/Subscribers/ServiceContainer.php
+++ b/Subscribers/ServiceContainer.php
@@ -75,7 +75,10 @@ class ServiceContainer extends BaseSubscriber
         $streamAttrRepository = $this->manager->getRepository('Shopware\CustomModels\Connect\ProductStreamAttribute');
 
         return new ProductStreamService(
-            new ProductStreamRepository($this->manager),
+            new ProductStreamRepository(
+                $this->manager,
+                $this->container->get('shopware.logaware_reflection_helper')
+            ),
             $streamAttrRepository,
             new Config($this->manager),
             $this->container->get('shopware_search.product_search'),


### PR DESCRIPTION
With shopware 5.3 the product stream repository has a new dependency "LogawareReflectionHelper" this. This is required to log exceptions in the deserialize process.
Please add a version switch or create a new plugin version which is only available for shopware 5.3