### PR TITLE
NTR - Add files to .sw-zip-blacklist

### DIFF
--- a/.sw-zip-blacklist
+++ b/.sw-zip-blacklist
@@ -1,1 +1,9 @@
 psh
+.gitignore
+.psh.yml
+.psh.yaml
+.psh.yml.dist
+.psh.yaml.dist
+Tests
+.travis.yml
+phpunit.xml


### PR DESCRIPTION
This adds files which will be ignored by the shopware release process