### PR TITLE
CON-4611 Check exported product on removeStreams

### DIFF
--- a/Components/ConnectExport.php
+++ b/Components/ConnectExport.php
@@ -385,6 +385,10 @@ class ConnectExport
     public function syncDeleteDetail(Detail $detail)
     {
         $attribute = $this->helper->getConnectAttributeByModel($detail);
+        // force fetching ConnectAttribute from DB
+        // if it was update via query builder
+        // changes are not visible, because of doctrine proxy cache
+        $this->manager->refresh($attribute);
 
         if (!$this->helper->isProductExported($attribute)) {
             return;

--- a/Components/ConnectExport.php
+++ b/Components/ConnectExport.php
@@ -143,6 +143,7 @@ class ConnectExport
         );
 
         $this->manager->beginTransaction();
+        $excludeInactiveProducts = $this->configComponent->getConfig('excludeInactiveProducts');
 
         foreach ($connectItems as &$item) {
             $model = $this->getArticleDetailById($item['articleDetailId']);
@@ -152,7 +153,6 @@ class ConnectExport
 
             $connectAttribute = $this->helper->getOrCreateConnectAttributeByModel($model);
 
-            $excludeInactiveProducts = $this->configComponent->getConfig('excludeInactiveProducts');
             if ($excludeInactiveProducts && !$model->getActive()) {
                 $this->updateLocalConnectItem(
                     $connectAttribute->getSourceId(),
@@ -313,6 +313,7 @@ class ConnectExport
                     bi.export_status as exportStatus,
                     bi.export_message as exportMessage,
                     bi.source_id as sourceId,
+                    bi.exported,
                     a.name as title,
                     IF (a.configurator_set_id IS NOT NULL, a.id, NULL) as groupId,
                     d.ordernumber as number
@@ -384,6 +385,7 @@ class ConnectExport
     public function syncDeleteDetail(Detail $detail)
     {
         $attribute = $this->helper->getConnectAttributeByModel($detail);
+
         if (!$this->helper->isProductExported($attribute)) {
             return;
         }

--- a/Components/Helper.php
+++ b/Components/Helper.php
@@ -315,9 +315,15 @@ class Helper
             if (!$model->getMainDetail()) {
                 return false;
             }
-            return $repository->findOneBy(array('articleDetailId' => $model->getMainDetail()->getId()));
+            $connectAttribute = $repository->findOneBy(array('articleDetailId' => $model->getMainDetail()->getId()));
+            $this->manager->refresh($connectAttribute);
+
+            return $connectAttribute;
         } elseif ($model instanceof ProductDetail) {
-            return $repository->findOneBy(array('articleDetailId' => $model->getId()));
+            $connectAttribute = $repository->findOneBy(array('articleDetailId' => $model->getId()));
+            $this->manager->refresh($connectAttribute);
+
+            return $connectAttribute;
         }
 
         return false;

--- a/Components/Helper.php
+++ b/Components/Helper.php
@@ -315,15 +315,10 @@ class Helper
             if (!$model->getMainDetail()) {
                 return false;
             }
-            $connectAttribute = $repository->findOneBy(array('articleDetailId' => $model->getMainDetail()->getId()));
-            $this->manager->refresh($connectAttribute);
 
-            return $connectAttribute;
+            return $repository->findOneBy(array('articleDetailId' => $model->getMainDetail()->getId()));
         } elseif ($model instanceof ProductDetail) {
-            $connectAttribute = $repository->findOneBy(array('articleDetailId' => $model->getId()));
-            $this->manager->refresh($connectAttribute);
-
-            return $connectAttribute;
+            return $repository->findOneBy(array('articleDetailId' => $model->getId()));
         }
 
         return false;

--- a/Controllers/Backend/ConnectBaseController.php
+++ b/Controllers/Backend/ConnectBaseController.php
@@ -1552,6 +1552,10 @@ class ConnectBaseController extends \Shopware_Controllers_Backend_ExtJs
                 $items = $connectExport->fetchConnectItems($sourceIds, false);
 
                 foreach ($items as $item) {
+                    if ($item['exported'] == false) {
+                        continue;
+                    }
+
                     if ($productStreamService->allowToRemove($assignments, $streamId, $item['articleId'])) {
                         $this->getSDK()->recordDelete($item['sourceId']);
                         $removedRecords[] = $item['sourceId'];


### PR DESCRIPTION
Don't need to generate stream assignment changes for products which are not exported to Connect system anymore.
Connect will skip them, but don't need to replicate superfluous changes.