### PR TITLE
CON-4735 Use addCategory instead of setCategories

### DIFF
--- a/Components/ProductToShop.php
+++ b/Components/ProductToShop.php
@@ -238,11 +238,6 @@ class ProductToShop implements ProductToShopBase
             if (!empty($product->variant)) {
                 $this->variantConfigurator->configureVariantAttributes($product, $detail);
             }
-
-            $categories = $this->categoryResolver->resolve($product->categories);
-            foreach ($categories as $category) {
-                $model->addCategory($category);
-            }
         } else {
             $model = $detail->getArticle();
             // fix for isMainVariant flag
@@ -251,6 +246,22 @@ class ProductToShop implements ProductToShopBase
             if ($detail->getId() === $mainDetail->getId()) {
                 $isMainVariant = true;
             }
+        }
+
+        /** @var \Shopware\Models\Category\Category $category */
+        foreach ($model->getCategories() as $category) {
+            $attribute = $category->getAttribute();
+            if (!$attribute) {
+                continue;
+            }
+
+            if ($attribute->getConnectImported()) {
+                $model->removeCategory($category);
+            }
+        }
+        $categories = $this->categoryResolver->resolve($product->categories);
+        foreach ($categories as $remoteCategory) {
+            $model->addCategory($remoteCategory);
         }
 
         if (!empty($product->sku)) {

--- a/Components/ProductToShop.php
+++ b/Components/ProductToShop.php
@@ -259,7 +259,17 @@ class ProductToShop implements ProductToShopBase
                 $model->removeCategory($category);
             }
         }
+
+        $detailAttribute = $detail->getAttribute();
+        if (!$detailAttribute) {
+            $detailAttribute = new AttributeModel();
+            $detail->setAttribute($detailAttribute);
+            $detailAttribute->setArticle($model);
+        }
+
         $categories = $this->categoryResolver->resolve($product->categories);
+        $hasMappedCategory = count($categories) > 0;
+        $detailAttribute->setConnectMappedCategory($hasMappedCategory);
         foreach ($categories as $remoteCategory) {
             $model->addCategory($remoteCategory);
         }
@@ -276,13 +286,6 @@ class ProductToShop implements ProductToShopBase
             $connectAttribute->setIsMainVariant(true);
         }
         $connectAttribute->setGroupId($product->groupId);
-
-        $detailAttribute = $detail->getAttribute();
-        if (!$detailAttribute) {
-            $detailAttribute = new AttributeModel();
-            $detail->setAttribute($detailAttribute);
-            $detailAttribute->setArticle($model);
-        }
 
         list($updateFields, $flag) = $this->getUpdateFields($model, $detail, $connectAttribute, $product);
         /*

--- a/Components/ProductToShop.php
+++ b/Components/ProductToShop.php
@@ -240,7 +240,9 @@ class ProductToShop implements ProductToShopBase
             }
 
             $categories = $this->categoryResolver->resolve($product->categories);
-            $model->setCategories($categories);
+            foreach ($categories as $category) {
+                $model->addCategory($category);
+            }
         } else {
             $model = $detail->getArticle();
             // fix for isMainVariant flag


### PR DESCRIPTION
In some cases we got error: QLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '639-7' for key 'articleID' in
With addCategory method this is not possible, because it will check if category is already added.