### PR TITLE
Use Interfaces instead of services for a better third party plugin compatibility

### DIFF
--- a/Components/ProductStream/ProductStreamService.php
+++ b/Components/ProductStream/ProductStreamService.php
@@ -7,14 +7,14 @@
 
 namespace ShopwarePlugins\Connect\Components\ProductStream;
 
-use Shopware\Bundle\SearchBundle\ProductSearch;
+use Shopware\Bundle\SearchBundle\ProductSearchInterface;
 use Shopware\Bundle\SearchBundle\ProductSearchResult;
 use Shopware\Bundle\StoreFrontBundle\Struct\ProductContext;
 use Shopware\CustomModels\Connect\ProductStreamAttribute;
 use Shopware\Models\ProductStream\ProductStream;
 use Shopware\CustomModels\Connect\ProductStreamAttributeRepository;
 use Shopware\Bundle\SearchBundle\Criteria;
-use Shopware\Bundle\StoreFrontBundle\Service\Core\ContextService;
+use Shopware\Bundle\StoreFrontBundle\Service\ContextServiceInterface;
 use Shopware\Bundle\SearchBundle\Condition\CategoryCondition;
 use Shopware\Bundle\SearchBundle\Condition\CustomerGroupCondition;
 use ShopwarePlugins\Connect\Components\Config;
@@ -50,25 +50,29 @@ class ProductStreamService
     /** @var Config */
     private $config;
 
-    /** @var ProductSearch */
+    /**
+     * @var ProductSearchInterface
+     */
     private $productSearchService;
 
-    /** @var ContextService */
+    /**
+     * @var ContextServiceInterface
+     */
     private $contextService;
 
     /**
      * @param ProductStreamRepository $productStreamRepository
      * @param ProductStreamAttributeRepository $streamAttrRepository
      * @param Config $config
-     * @param ProductSearch $productSearchService
-     * @param ContextService $contextService
+     * @param ProductSearchInterface $productSearchService
+     * @param ContextServiceInterface $contextService
      */
     public function __construct(
         ProductStreamRepository $productStreamRepository,
         ProductStreamAttributeRepository $streamAttrRepository,
         Config $config,
-        ProductSearch $productSearchService,
-        ContextService $contextService
+        ProductSearchInterface $productSearchService,
+        ContextServiceInterface $contextService
     ) {
         $this->productStreamRepository = $productStreamRepository;
         $this->streamAttrRepository = $streamAttrRepository;


### PR DESCRIPTION
When the `ProductSearch` or `ContextService` class are decorated by a third party plugin, the following error occurs:
```
PHP Fatal error:  Uncaught TypeError: Argument 4 passed to ShopwarePlugins\Connect\Components\ProductStream\ProductStreamService::__construct() must be an instance of Shopware\Bundle\SearchBundle\ProductSearch, instance of Shopware\SwkweListingSoldout\SearchBundle\ProductSearch given, called in /var/www/xxx/current/engine/Shopware/Plugins/Community/Backend/SwagConnect/Subscribers/ServiceContainer.php on line 87 and defined in /var/www/xxx/current/engine/Shopware/Plugins/Community/Backend/SwagConnect/Components/ProductStream/ProductStreamService.php:66
```
This pull request fixes this issue.