### PR TITLE
NTR Fix delete variants

### DIFF
--- a/Components/ProductToShop.php
+++ b/Components/ProductToShop.php
@@ -232,8 +232,9 @@ class ProductToShop implements ProductToShopBase
 
             $detail = new DetailModel();
             $detail->setActive($model->getActive());
-
+            $this->manager->persist($detail);
             $detail->setArticle($model);
+            $model->getDetails()->add($detail);
             if (!empty($product->variant)) {
                 $this->variantConfigurator->configureVariantAttributes($product, $detail);
             }
@@ -265,7 +266,9 @@ class ProductToShop implements ProductToShopBase
         if (!$detailAttribute) {
             $detailAttribute = new AttributeModel();
             $detail->setAttribute($detailAttribute);
+            $model->setAttribute($detailAttribute);
             $detailAttribute->setArticle($model);
+            $detailAttribute->setArticleDetail($detail);
         }
 
         $connectAttribute = $this->helper->getConnectAttributeByModel($detail) ?: new ConnectAttribute;
@@ -441,14 +444,14 @@ class ProductToShop implements ProductToShopBase
             ]
         );
 
-        $this->manager->persist($connectAttribute);
-        $this->manager->persist($detail);
-
         $categories = $this->categoryResolver->resolve($product->categories);
         if (count($categories) > 0) {
             $detailAttribute->setConnectMappedCategory(true);
         }
 
+        $this->manager->persist($connectAttribute);
+        $this->manager->persist($model);
+        $this->manager->persist($detail);
         //article has to be flushed
         $this->manager->persist($detailAttribute);
         $this->manager->flush();
@@ -816,9 +819,7 @@ class ProductToShop implements ProductToShopBase
             ]
         );
 
-
         $article = $detailModel->getArticle();
-        $isMainVariant = $detailModel->getKind() === 1;
         // Not sure why, but the Attribute can be NULL
         $attribute = $this->helper->getConnectAttributeByModel($detailModel);
         $this->manager->remove($detailModel);
@@ -827,20 +828,18 @@ class ProductToShop implements ProductToShopBase
             $this->manager->remove($attribute);
         }
 
-        if (count($details = $article->getDetails()) === 1) {
-            $details->clear();
-            $this->manager->remove($article);
-        }
-
         // if removed variant is main variant
         // find first variant which is not main and mark it
-        if ($isMainVariant) {
+        if ($detailModel->getKind() === 1) {
             /** @var \Shopware\Models\Article\Detail $variant */
             foreach ($article->getDetails() as $variant) {
                 if ($variant->getId() != $detailModel->getId()) {
                     $variant->setKind(1);
                     $article->setMainDetail($variant);
                     $connectAttribute = $this->helper->getConnectAttributeByModel($variant);
+                    if (!$connectAttribute) {
+                        continue;
+                    }
                     $connectAttribute->setIsMainVariant(true);
                     $this->manager->persist($connectAttribute);
                     $this->manager->persist($article);
@@ -850,10 +849,18 @@ class ProductToShop implements ProductToShopBase
             }
         }
 
+        if (count($details = $article->getDetails()) === 1) {
+            $details->clear();
+            $this->manager->remove($article);
+        }
+
         // Do not remove flush. It's needed when remove article,
         // because duplication of ordernumber. Even with remove before
         // persist calls mysql throws exception "Duplicate entry"
         $this->manager->flush();
+        // always clear entity manager, because $article->getDetails() returns
+        // more than 1 detail, but all of them were removed except main one.
+        $this->manager->clear();
     }
 
     /**

--- a/Tests/Integration/Components/ProductToShopTest.php
+++ b/Tests/Integration/Components/ProductToShopTest.php
@@ -274,4 +274,52 @@ class ProductToShopTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedArticleId, $actualArticleId);
         $this->assertEquals($expectedArticleDetailId, $actualArticleDetailId);
     }
+
+    /**
+     * Insert 4 remote variants. Then delete them one by one.
+     * Main variant must be removed at the end.
+     * Then the whole product will be removed.
+     */
+    public function test_delete_variant_by_variant()
+    {
+        $variants = $this->getVariants();
+        foreach ($variants as $variant) {
+            $this->productToShop->insertOrUpdate($variant);
+        }
+        $articleId = $this->manager->getConnection()->fetchColumn(
+            'SELECT article_id FROM s_plugin_connect_items WHERE source_id = ? AND shop_id = ?',
+            [$variants[0]->sourceId, $variants[0]->shopId]
+        );
+        $connectItems = $this->manager->getConnection()->fetchAll(
+            'SELECT article_id, article_detail_id, source_id, shop_id FROM s_plugin_connect_items WHERE article_id = ?',
+            [$articleId]
+        );
+        $this->assertCount(4, $connectItems);
+        // verify that $variants[0] is main variant
+        $this->assertEquals($variants[0]->sourceId, $connectItems[0]['source_id']);
+        $kind = $this->manager->getConnection()->fetchColumn(
+            'SELECT kind FROM s_articles_details WHERE id = ?',
+            [$connectItems[0]['article_detail_id']]
+        );
+        $this->assertEquals(1, $kind);
+        $this->productToShop->delete($variants[3]->shopId, $variants[3]->sourceId);
+        $this->productToShop->delete($variants[2]->shopId, $variants[2]->sourceId);
+        $this->productToShop->delete($variants[1]->shopId, $variants[1]->sourceId);
+        $this->productToShop->delete($variants[0]->shopId, $variants[0]->sourceId);
+        $newConnectItems = $this->manager->getConnection()->fetchAll(
+            'SELECT article_id, article_detail_id, source_id, shop_id FROM s_plugin_connect_items WHERE article_id = ?',
+            [$articleId]
+        );
+        $this->assertCount(0, $newConnectItems);
+        $detailsCount = $this->manager->getConnection()->fetchColumn(
+            'SELECT COUNT(id) FROM s_articles_details WHERE articleID = ?',
+            [$articleId]
+        );
+        $this->assertEquals(0, $detailsCount);
+        $articleCount = $this->manager->getConnection()->fetchColumn(
+            'SELECT COUNT(id) FROM s_articles WHERE id = ?',
+            [$articleId]
+        );
+        $this->assertEquals(0, $articleCount);
+    }
 }


### PR DESCRIPTION
Always clear entity manager, because $article->getDetails() returns
more than 1 detail, even when all of them were removed except main one.