### PR TITLE
CON-4871 Fill $product->variants when configuratorSet exists

### DIFF
--- a/Components/ProductQuery/LocalProductQuery.php
+++ b/Components/ProductQuery/LocalProductQuery.php
@@ -172,6 +172,7 @@ class LocalProductQuery extends BaseProductQuery
             'at.fixedPrice as fixedPrice',
             'd.shippingTime as deliveryWorkDays',
             'a.lastStock',
+            'a.configuratorSetId',
         ];
 
         if ($this->configComponent->getConfig(self::SHORT_DESCRIPTION_FIELD, false)) {
@@ -262,8 +263,6 @@ class LocalProductQuery extends BaseProductQuery
             }
         }
 
-        //todo@sb: find better way to collect configuration option translations
-        $row = $this->applyConfiguratorOptions($row);
         $row = $this->prepareVendor($row);
 
         if ($row['deliveryWorkDays']) {
@@ -272,13 +271,14 @@ class LocalProductQuery extends BaseProductQuery
             $row['deliveryWorkDays'] = null;
         }
 
-        if ($this->hasVariants($row['localId'])) {
+        if ($row['configuratorSetId'] > 0) {
             $row['groupId'] = $row['localId'];
+            $row = $this->applyConfiguratorOptions($row);
         }
 
-        unset($row['localId']);
-        unset($row['detailId']);
-        unset($row['detailKind']);
+        foreach (['localId', 'detailId', 'detailKind', 'configuratorSetId'] as $fieldName) {
+            unset($row[$fieldName]);
+        }
 
         if (
             (array_key_exists(Product::ATTRIBUTE_UNIT, $row['attributes']) && $row['attributes'][Product::ATTRIBUTE_UNIT]) &&

--- a/Components/ProductQuery/LocalProductQuery.php
+++ b/Components/ProductQuery/LocalProductQuery.php
@@ -438,14 +438,14 @@ class LocalProductQuery extends BaseProductQuery
     /**
      * Check whether the product contains variants
      *
-     * @param int $productId
+     * @param int $articleId
      * @return bool
      */
-    public function hasVariants($productId)
+    public function hasVariants($articleId)
     {
         $result = $this->manager->getConnection()->fetchColumn(
             'SELECT a.configurator_set_id FROM s_articles a WHERE a.id = ?',
-            [(int) $productId]
+            [(int) $articleId]
         );
 
         return $result > 0;

--- a/Components/ProductToShop.php
+++ b/Components/ProductToShop.php
@@ -245,6 +245,13 @@ class ProductToShop implements ProductToShopBase
             if ($detail->getId() === $mainDetail->getId()) {
                 $isMainVariant = true;
             }
+
+            if (empty($product->variant) && $model->getConfiguratorSet()) {
+                $this->manager->getConnection()->executeQuery(
+                    'UPDATE s_articles SET configurator_set_id = NULL WHERE id = ?',
+                    [$model->getId()]
+                );
+            }
         }
 
         $detail->setNumber($number);

--- a/Tests/Integration/Components/ProductQuery/LocalProductQueryTest.php
+++ b/Tests/Integration/Components/ProductQuery/LocalProductQueryTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ShopwarePlugins\Connect\Tests\Integration\Components\ProductQuery;
+
+use ShopwarePlugins\Connect\Components\ConfigFactory;
+use ShopwarePlugins\Connect\Components\Gateway\ProductTranslationsGateway\PdoProductTranslationsGateway;
+use ShopwarePlugins\Connect\Components\Marketplace\MarketplaceGateway;
+use ShopwarePlugins\Connect\Components\MediaService\LocalMediaService;
+use ShopwarePlugins\Connect\Components\ProductQuery\LocalProductQuery;
+use ShopwarePlugins\Connect\Components\Translations\ProductTranslator;
+use ShopwarePlugins\Connect\Tests\DatabaseTestCaseTrait;
+use Shopware\Components\Model\ModelManager;
+
+class LocalProductQueryTest extends \PHPUnit_Framework_TestCase
+{
+    use DatabaseTestCaseTrait;
+
+    /**
+     * @var LocalProductQuery
+     */
+    private $localProductQuery;
+
+    /**
+     * @var ModelManager
+     */
+    private $manager;
+
+    public function setUp()
+    {
+        $this->manager = Shopware()->Models();
+        $config = ConfigFactory::getConfigInstance();
+
+        $this->localProductQuery = new LocalProductQuery(
+            $this->manager,
+            $this->getProductBaseUrl(),
+            $config,
+            new MarketplaceGateway($this->manager),
+            new ProductTranslator(
+                $config,
+                new PdoProductTranslationsGateway(Shopware()->Db()),
+                $this->manager,
+                $this->getProductBaseUrl()
+            ),
+            Shopware()->Container()->get('shopware_storefront.context_service'),
+            new LocalMediaService(
+                Shopware()->Container()->get('shopware_storefront.product_media_gateway'),
+                Shopware()->Container()->get('shopware_storefront.variant_media_gateway'),
+                Shopware()->Container()->get('shopware_storefront.media_service')
+            ),
+            Shopware()->Container()->get('events'),
+            Shopware()->Container()->get('shopware_media.media_service')
+        );
+    }
+
+    /**
+     * When configurator_set_id column is empty in s_articles is NULL,
+     * product must be exported as a article without variants even
+     * when it has relations with configurator options
+     */
+    public function test_export_product_without_configurator_set()
+    {
+        $this->manager->getConnection()->executeQuery(
+            'INSERT INTO s_plugin_connect_items (article_id, article_detail_id, source_id) VALUES (?, ?, ?);',
+            [2, 123, '2-123']
+        );
+
+        $result = $this->localProductQuery->get(['2-123']);
+        $product = reset($result);
+        $this->assertNotEmpty($product->variant);
+
+        $this->manager->getConnection()->executeQuery(
+            'UPDATE s_articles SET configurator_set_id = NULL WHERE id = 2'
+        );
+
+        $result = $this->localProductQuery->get(['2-123']);
+        $product = reset($result);
+        $this->assertEmpty($product->variant);
+    }
+
+    private function getProductBaseUrl()
+    {
+        if (!Shopware()->Front()->Router()) {
+            return null;
+        }
+
+        return Shopware()->Front()->Router()->assemble([
+            'module' => 'frontend',
+            'controller' => 'connect_product_gateway',
+            'action' => 'product',
+            'id' => '',
+            'fullPath' => true
+        ]);
+    }
+}

--- a/Tests/Integration/Components/ProductQuery/LocalProductQueryTest.php
+++ b/Tests/Integration/Components/ProductQuery/LocalProductQueryTest.php
@@ -82,6 +82,11 @@ class LocalProductQueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($product->variant);
     }
 
+    public function test_has_variants()
+    {
+        $this->assertTrue($this->localProductQuery->hasVariants(2));
+    }
+
     private function getProductBaseUrl()
     {
         if (!Shopware()->Front()->Router()) {

--- a/Tests/Integration/Components/ProductToShopTest.php
+++ b/Tests/Integration/Components/ProductToShopTest.php
@@ -274,4 +274,27 @@ class ProductToShopTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedArticleId, $actualArticleId);
         $this->assertEquals($expectedArticleDetailId, $actualArticleDetailId);
     }
+
+    /**
+     * Import variant, set empty variant and groupId properties.
+     * Import it again, configurator_set_id column must be null.
+     * By this way Variants checkbox will be deselected
+     */
+    public function test_migrate_variant_to_article()
+    {
+        $variants = $this->getVariants();
+
+        $this->productToShop->insertOrUpdate($variants[0]);
+
+        $variants[0]->variant = [];
+        $variants[0]->groupId = null;
+        $this->productToShop->insertOrUpdate($variants[0]);
+
+        $articleId = $this->manager->getConnection()->fetchColumn(
+            'SELECT article_id FROM s_plugin_connect_items WHERE source_id = ? AND shop_id = ?',
+            [$variants[0]->sourceId, $variants[0]->shopId]
+        );
+        $configuratorSetId = $this->manager->getConnection()->fetchColumn('SELECT configurator_set_id FROM s_articles WHERE id = ?', [$articleId]);
+        $this->assertNull($configuratorSetId);
+    }
 }

--- a/Tests/Legacy/Shopware/Connect/Component/ProductQuery/LocalProductQueryTest.php
+++ b/Tests/Legacy/Shopware/Connect/Component/ProductQuery/LocalProductQueryTest.php
@@ -366,6 +366,7 @@ class LocalProductQueryTest extends ConnectTestHelper
         $row['unit'] = null;
         $row['localId'] = $this->article->getId();
         $row['detailId'] = $this->article->getMainDetail()->getId();
+        $row['configuratorSetId'] = null;
 
         $this->assertEquals($expectedProduct, $this->getLocalProductQuery()->getConnectProduct($row));
     }


### PR DESCRIPTION
Collect variant options only where configurator_set_id column in s_articles table is not null