### PR TITLE
CON-4922 Refactor storefront usage in stream export

### DIFF
--- a/Bootstrap/SubscriberRegistration.php
+++ b/Bootstrap/SubscriberRegistration.php
@@ -192,7 +192,8 @@ class SubscriberRegistration
                 $this->SDK,
                 $this->connectFactory->getConnectExport(),
                 $this->config,
-                $this->helper
+                $this->helper,
+                $this->container
             ),
             new CustomerGroup(
                 $this->modelManager,
@@ -293,9 +294,7 @@ class SubscriberRegistration
         return new ProductStreamService(
             new ProductStreamRepository($this->modelManager, $this->container->get('shopware_product_stream.repository')),
             $streamAttrRepository,
-            $this->config,
-            $this->container->get('shopware_search.product_search'),
-            $this->container->get('shopware_storefront.context_service')
+            $this->config
         );
     }
 

--- a/Bootstrap/SubscriberRegistration.php
+++ b/Bootstrap/SubscriberRegistration.php
@@ -11,6 +11,7 @@ use Enlight_Components_Db_Adapter_Pdo_Mysql;
 use Shopware\Components\Model\ModelManager;
 use Shopware\Connect\Gateway\PDO;
 use Shopware\Connect\SDK;
+use Shopware\CustomModels\Connect\ProductStreamAttributeRepository;
 use ShopwarePlugins\Connect\Components\Config;
 use ShopwarePlugins\Connect\Components\ConnectFactory;
 use ShopwarePlugins\Connect\Components\Helper;
@@ -193,7 +194,8 @@ class SubscriberRegistration
                 $this->connectFactory->getConnectExport(),
                 $this->config,
                 $this->helper,
-                $this->container
+                $this->container,
+                $this->createProductStreamService()
             ),
             new CustomerGroup(
                 $this->modelManager,

--- a/Components/ProductStream/ProductSearch.php
+++ b/Components/ProductStream/ProductSearch.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace ShopwarePlugins\Connect\Components\ProductStream;
 
@@ -40,8 +45,7 @@ class ProductSearch
         Config $config,
         ProductSearchInterface $productSearchService,
         ContextServiceInterface $contextService
-    )
-    {
+    ) {
         $this->productStreamRepository = $productStreamRepository;
         $this->config = $config;
         $this->productSearchService = $productSearchService;

--- a/Components/ProductStream/ProductSearch.php
+++ b/Components/ProductStream/ProductSearch.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace ShopwarePlugins\Connect\Components\ProductStream;
+
+use Shopware\Models\ProductStream\ProductStream;
+use Shopware\Bundle\SearchBundle\ProductSearchResult;
+use Shopware\Bundle\SearchBundle\Criteria;
+use Shopware\Bundle\SearchBundle\Condition\CustomerGroupCondition;
+use Shopware\Bundle\SearchBundle\Condition\CategoryCondition;
+use Shopware\Bundle\SearchBundle\ProductSearchInterface;
+use Shopware\Bundle\StoreFrontBundle\Service\ContextServiceInterface;
+use ShopwarePlugins\Connect\Components\Config;
+use Shopware\Bundle\StoreFrontBundle\Struct\ShopContext;
+use Shopware\Components\ProductStream\Repository as StreamRepository;
+
+class ProductSearch
+{
+    /**
+     * @var StreamRepository
+     */
+    private $productStreamRepository;
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @var ProductSearchInterface
+     */
+    private $productSearchService;
+
+    /**
+     * @var ContextServiceInterface
+     */
+    private $contextService;
+
+    public function __construct(
+        StreamRepository $productStreamRepository,
+        Config $config,
+        ProductSearchInterface $productSearchService,
+        ContextServiceInterface $contextService
+    )
+    {
+        $this->productStreamRepository = $productStreamRepository;
+        $this->config = $config;
+        $this->productSearchService = $productSearchService;
+        $this->contextService = $contextService;
+    }
+
+    /**
+     * @param ProductStream $stream
+     * @return ProductSearchResult
+     */
+    public function getProductFromConditionStream(ProductStream $stream)
+    {
+        $criteria = new Criteria();
+
+        $conditions = json_decode($stream->getConditions(), true);
+        $conditions = $this->productStreamRepository->unserialize($conditions);
+
+        foreach ($conditions as $condition) {
+            $criteria->addCondition($condition);
+        }
+
+        $sorting = json_decode($stream->getSorting(), true);
+        $sorting = $this->productStreamRepository->unserialize($sorting);
+
+        foreach ($sorting as $sort) {
+            $criteria->addSorting($sort);
+        }
+
+        /** @var ShopContext $context */
+        $context = $this->contextService->createShopContext($this->config->getDefaultShopId());
+
+        $criteria->addBaseCondition(
+            new CustomerGroupCondition([$context->getCurrentCustomerGroup()->getId()])
+        );
+
+        $criteria->addBaseCondition(
+            new CategoryCondition([$context->getShop()->getCategory()->getId()])
+        );
+
+        return $this->productSearchService->search($criteria, $context);
+    }
+}

--- a/Components/ProductStream/ProductStreamService.php
+++ b/Components/ProductStream/ProductStreamService.php
@@ -7,16 +7,9 @@
 
 namespace ShopwarePlugins\Connect\Components\ProductStream;
 
-use Shopware\Bundle\SearchBundle\ProductSearchInterface;
-use Shopware\Bundle\SearchBundle\ProductSearchResult;
-use Shopware\Bundle\StoreFrontBundle\Struct\ProductContext;
 use Shopware\CustomModels\Connect\ProductStreamAttribute;
 use Shopware\Models\ProductStream\ProductStream;
 use Shopware\CustomModels\Connect\ProductStreamAttributeRepository;
-use Shopware\Bundle\SearchBundle\Criteria;
-use Shopware\Bundle\StoreFrontBundle\Service\ContextServiceInterface;
-use Shopware\Bundle\SearchBundle\Condition\CategoryCondition;
-use Shopware\Bundle\SearchBundle\Condition\CustomerGroupCondition;
 use ShopwarePlugins\Connect\Components\Config;
 
 class ProductStreamService
@@ -51,34 +44,18 @@ class ProductStreamService
     private $config;
 
     /**
-     * @var ProductSearchInterface
-     */
-    private $productSearchService;
-
-    /**
-     * @var ContextServiceInterface
-     */
-    private $contextService;
-
-    /**
      * @param ProductStreamRepository $productStreamRepository
      * @param ProductStreamAttributeRepository $streamAttrRepository
      * @param Config $config
-     * @param ProductSearchInterface $productSearchService
-     * @param ContextServiceInterface $contextService
      */
     public function __construct(
         ProductStreamRepository $productStreamRepository,
         ProductStreamAttributeRepository $streamAttrRepository,
-        Config $config,
-        ProductSearchInterface $productSearchService,
-        ContextServiceInterface $contextService
+        Config $config
     ) {
         $this->productStreamRepository = $productStreamRepository;
         $this->streamAttrRepository = $streamAttrRepository;
         $this->config = $config;
-        $this->productSearchService = $productSearchService;
-        $this->contextService = $contextService;
     }
 
     /**
@@ -311,42 +288,6 @@ class ProductStreamService
     public function countProductsInStaticStream($streamId)
     {
         return $this->productStreamRepository->countProductsInStaticStream($streamId);
-    }
-
-    /**
-     * @param ProductStream $stream
-     * @return ProductSearchResult
-     */
-    public function getProductFromConditionStream(ProductStream $stream)
-    {
-        $criteria = new Criteria();
-
-        $conditions = json_decode($stream->getConditions(), true);
-        $conditions = $this->productStreamRepository->unserialize($conditions);
-
-        foreach ($conditions as $condition) {
-            $criteria->addCondition($condition);
-        }
-
-        $sorting = json_decode($stream->getSorting(), true);
-        $sorting = $this->productStreamRepository->unserialize($sorting);
-
-        foreach ($sorting as $sort) {
-            $criteria->addSorting($sort);
-        }
-
-        /** @var ProductContext $context */
-        $context = $this->contextService->createShopContext($this->config->getDefaultShopId());
-
-        $criteria->addBaseCondition(
-            new CustomerGroupCondition([$context->getCurrentCustomerGroup()->getId()])
-        );
-
-        $criteria->addBaseCondition(
-            new CategoryCondition([$context->getShop()->getCategory()->getId()])
-        );
-
-        return $this->productSearchService->search($criteria, $context);
     }
 
     /**

--- a/Subscribers/ServiceContainer.php
+++ b/Subscribers/ServiceContainer.php
@@ -20,6 +20,7 @@ use ShopwarePlugins\Connect\Components\Config;
 use ShopwarePlugins\Connect\Components\CategoryResolver\DefaultCategoryResolver;
 use ShopwarePlugins\Connect\Components\FrontendQuery\FrontendQuery;
 use ShopwarePlugins\Connect\Components\ImportService;
+use ShopwarePlugins\Connect\Components\ProductStream\ProductSearch;
 use ShopwarePlugins\Connect\Components\ProductStream\ProductStreamRepository;
 use ShopwarePlugins\Connect\Components\ProductStream\ProductStreamService;
 use Shopware\CustomModels\Connect\ProductStreamAttributeRepository;
@@ -79,6 +80,7 @@ class ServiceContainer implements SubscriberInterface
     {
         return [
             'Enlight_Bootstrap_InitResource_swagconnect.product_stream_service' => 'onProductStreamService',
+            'Enlight_Bootstrap_InitResource_swagconnect.product_search' => 'onProductSearch',
             'Enlight_Bootstrap_InitResource_swagconnect.payment_service' => 'onPaymentService',
             'Enlight_Bootstrap_InitResource_swagconnect.menu_service' => 'onMenuService',
             'Enlight_Bootstrap_InitResource_swagconnect.frontend_query' => 'onCreateFrontendQuery',
@@ -101,6 +103,17 @@ class ServiceContainer implements SubscriberInterface
         return new ProductStreamService(
             new ProductStreamRepository($this->manager, $this->container->get('shopware_product_stream.repository')),
             $streamAttrRepository,
+            $this->config
+        );
+    }
+
+    /**
+     * @return ProductSearch
+     */
+    public function onProductSearch()
+    {
+        return new ProductSearch(
+            $this->container->get('shopware_product_stream.repository'),
             $this->config,
             $this->container->get('shopware_search.product_search'),
             $this->container->get('shopware_storefront.context_service')

--- a/Tests/Integration/Subscribers/ServiceContainerTest.php
+++ b/Tests/Integration/Subscribers/ServiceContainerTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ShopwarePlugins\Connect\Tests\Integration\Subscribers;
+
+use ShopwarePlugins\Connect\Components\Config;
+use ShopwarePlugins\Connect\Components\ProductStream\ProductSearch;
+use ShopwarePlugins\Connect\Subscribers\ServiceContainer;
+use ShopwarePlugins\Connect\Tests\ConnectTestHelperTrait;
+use ShopwarePlugins\Connect\Tests\DatabaseTestCaseTrait;
+
+class ServiceContainerTest extends \PHPUnit_Framework_TestCase
+{
+    use DatabaseTestCaseTrait;
+    use ConnectTestHelperTrait;
+
+    /**
+     * @var ServiceContainer
+     */
+    private $serviceContainer;
+
+    private $config;
+
+    public function setUp()
+    {
+        $this->config = $this->createMock(Config::class);
+        $this->serviceContainer = new ServiceContainer(
+            Shopware()->Models(),
+            Shopware()->Db(),
+            Shopware()->Container(),
+            $this->config
+        );
+    }
+
+    public function testOnProductSearch()
+    {
+        $this->assertInstanceOf(ProductSearch::class, $this->serviceContainer->onProductSearch());
+    }
+}

--- a/Tests/Unit/Subscribers/CronJobTest.php
+++ b/Tests/Unit/Subscribers/CronJobTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace ShopwarePlugins\Connect\Tests\Unit\Subscribers;
+
+use Shopware\Bundle\SearchBundle\ProductSearchResult;
+use ShopwarePlugins\Connect\Components\Config;
+use ShopwarePlugins\Connect\Components\ConnectExport;
+use ShopwarePlugins\Connect\Components\ConnectFactory;
+use ShopwarePlugins\Connect\Components\Helper;
+use ShopwarePlugins\Connect\Components\ProductStream\ProductSearch;
+use ShopwarePlugins\Connect\Components\ProductStream\ProductStreamsAssignments;
+use ShopwarePlugins\Connect\Components\ProductStream\ProductStreamService;
+use ShopwarePlugins\Connect\Subscribers\CronJob;
+use Shopware\Components\DependencyInjection\Container;
+use Shopware\Models\ProductStream\ProductStream;
+use Shopware\Bundle\StoreFrontBundle\Struct\ListProduct;
+
+class CronJobTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CronJob
+     */
+    private $cronJob;
+
+    /**
+     * @var Container
+     */
+    private $container;
+
+    private $streamService;
+
+    private $productSearch;
+
+    private $helper;
+
+    private $connectExport;
+
+    /**
+     * @before
+     */
+    public function prepareMocks()
+    {
+        $this->container = $this->createMock(Container::class);
+        $this->streamService = $this->createMock(ProductStreamService::class);
+        $this->productSearch = $this->createMock(ProductSearch::class);
+        $this->helper = $this->createMock(Helper::class);
+        $this->connectExport = $this->createMock(ConnectExport::class);
+
+        $this->container
+            ->expects($this->any())
+            ->method('get')
+            ->will($this->returnValueMap([
+                ['swagconnect.product_stream_service', Container::EXCEPTION_ON_INVALID_REFERENCE, $this->streamService],
+                ['swagconnect.product_search', Container::EXCEPTION_ON_INVALID_REFERENCE, $this->productSearch]
+            ]));
+
+        $this->cronJob = new CronJob(
+            (new ConnectFactory())->getSDK(),
+            $this->connectExport,
+            $this->createMock(Config::class),
+            $this->helper,
+            $this->container
+        );
+    }
+
+    public function test_subscribed_events()
+    {
+        $this->assertSame(
+            [
+                'Shopware_CronJob_ShopwareConnectImportImages' => 'importImages',
+                'Shopware_CronJob_ShopwareConnectUpdateProducts' => 'updateProducts',
+                'Shopware_CronJob_ConnectExportDynamicStreams' => 'exportDynamicStreams',
+            ],
+            CronJob::getSubscribedEvents()
+        );
+    }
+
+    public function test_without_exported_dynamic_stream()
+    {
+        $this->container
+            ->expects($this->any())
+            ->method('get')
+            ->will($this->returnValueMap([
+                ['swagconnect.product_stream_service', Container::EXCEPTION_ON_INVALID_REFERENCE, $this->streamService],
+            ]));
+
+        $this->streamService->expects($this->once())
+            ->method('getAllExportedStreams')
+            ->with(ProductStreamService::DYNAMIC_STREAM)
+            ->willReturn([]);
+
+        $this->cronJob->exportDynamicStreams(new \Shopware_Components_Cron_CronJob());
+    }
+
+    public function test_export_dynamic_stream()
+    {
+        $stream = $this->createMock(ProductStream::class);
+        $stream->expects($this->once())
+            ->method('getId')
+            ->willReturn(5);
+
+        $this->productSearch->expects($this->once())
+            ->method('getProductFromConditionStream')
+            ->with($stream)
+            ->willReturn(new ProductSearchResult([
+                'SW100001' => new ListProduct(14, 26, 'SW100001'),
+                'SW100003' => new ListProduct(15, 35, 'SW100002'),
+            ], 2, []));
+
+        $this->helper->expects($this->once())
+            ->method('getArticleIdsByNumber')
+            ->with(['SW100001', 'SW100003'])
+            ->willReturn([14, 15]);
+
+        $this->helper->expects($this->once())
+            ->method('getArticleSourceIds')
+            ->with([14, 15])
+            ->willReturn([14, 15]);
+
+        $this->streamService->expects($this->once())
+            ->method('getAllExportedStreams')
+            ->with(ProductStreamService::DYNAMIC_STREAM)
+            ->willReturn([
+                $stream
+            ]);
+
+        $this->streamService->expects($this->once())
+            ->method('createStreamRelation')
+            ->with(5, [14, 15]);
+
+        $assignment = [
+            14 => [
+                5 => 'Shoes Stream'
+            ],
+            15 => [
+                5 => 'Shoes Stream'
+            ]
+        ];
+        $streamAssignments = new ProductStreamsAssignments(
+            ['assignments' => $assignment]
+        );
+        $this->streamService->expects($this->once())
+            ->method('prepareStreamsAssignments')
+            ->with(5, false)
+            ->willReturn($streamAssignments);
+
+        $this->connectExport->expects($this->once())
+            ->method('export')
+            ->with([14, 15], $streamAssignments)
+            ->willReturn([]);
+
+        $this->streamService->expects($this->once())
+            ->method('changeStatus')
+            ->with(5, ProductStreamService::STATUS_EXPORT);
+
+        $this->cronJob->exportDynamicStreams(new \Shopware_Components_Cron_CronJob());
+    }
+}

--- a/Tests/Unit/Subscribers/CronJobTest.php
+++ b/Tests/Unit/Subscribers/CronJobTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace ShopwarePlugins\Connect\Tests\Unit\Subscribers;
 
@@ -59,7 +64,8 @@ class CronJobTest extends \PHPUnit_Framework_TestCase
             $this->connectExport,
             $this->createMock(Config::class),
             $this->helper,
-            $this->container
+            $this->container,
+            $this->streamService
         );
     }
 
@@ -77,13 +83,6 @@ class CronJobTest extends \PHPUnit_Framework_TestCase
 
     public function test_without_exported_dynamic_stream()
     {
-        $this->container
-            ->expects($this->any())
-            ->method('get')
-            ->will($this->returnValueMap([
-                ['swagconnect.product_stream_service', Container::EXCEPTION_ON_INVALID_REFERENCE, $this->streamService],
-            ]));
-
         $this->streamService->expects($this->once())
             ->method('getAllExportedStreams')
             ->with(ProductStreamService::DYNAMIC_STREAM)

--- a/Tests/Unit/Subscribers/ServiceContainerTest.php
+++ b/Tests/Unit/Subscribers/ServiceContainerTest.php
@@ -81,6 +81,7 @@ class ServiceContainerTest extends AbstractConnectUnitTest
         $this->assertSame(
             [
                 'Enlight_Bootstrap_InitResource_swagconnect.product_stream_service' => 'onProductStreamService',
+                'Enlight_Bootstrap_InitResource_swagconnect.product_search' => 'onProductSearch',
                 'Enlight_Bootstrap_InitResource_swagconnect.payment_service' => 'onPaymentService',
                 'Enlight_Bootstrap_InitResource_swagconnect.menu_service' => 'onMenuService',
                 'Enlight_Bootstrap_InitResource_swagconnect.frontend_query' => 'onCreateFrontendQuery',


### PR DESCRIPTION
Storefront namespace is designed to be used only in shopware frontend,
but we need to fetch articles/detal by stream id during stream export in backend.
Problem is that ShopContext is using Shop entity and it will break current session in DB.
With this PR Storefront namespace is not used anymore as a dependency.