### PR TITLE
CON-4907: create Tax if it not exists in ToShop

### DIFF
--- a/Components/ProductToShop.php
+++ b/Components/ProductToShop.php
@@ -1206,10 +1206,10 @@ class ProductToShop implements ProductToShopBase
      * @param Product $product
      * @param ProductModel $model
      */
-    private function saveVat(Product $product, $model)
+    private function saveVat(Product $product, ProductModel $model)
     {
         if ($product->vat !== null) {
-            $repo = $this->manager->getRepository('Shopware\Models\Tax\Tax');
+            $repo = $this->manager->getRepository(Tax::class);
             $taxRate = round($product->vat * 100, 2);
             /** @var \Shopware\Models\Tax\Tax $tax */
             $tax = $repo->findOneBy(['tax' => $taxRate]);


### PR DESCRIPTION
if the supplier has taxes with values the merchant hasn't no tax
was assigned to the Product in ProductToShop.
Now a new Tax with the value of the supplier is created and assigned.