### PR TITLE
CON-4935: created remote categories get correct creation date

### DIFF
--- a/Components/CategoryResolver.php
+++ b/Components/CategoryResolver.php
@@ -198,9 +198,11 @@ abstract class CategoryResolver
             [$parentId]);
         $suffix = ($path) ? "$parentId|" : "|$parentId|";
         $path = $path . $suffix;
-        $this->manager->getConnection()->executeQuery('INSERT INTO `s_categories` (`description`, `parent`, `path`, `active`) 
-            VALUES (?, ?, ?, 1)',
-            [$categoryName, $parentId, $path]);
+        $now = new \DateTime('now');
+        $timestamp = $now->format('Y-m-d H:i:s');
+        $this->manager->getConnection()->executeQuery('INSERT INTO `s_categories` (`description`, `parent`, `path`, `active`, `added`, `changed`) 
+            VALUES (?, ?, ?, 1, ?, ?)',
+            [$categoryName, $parentId, $path, $timestamp, $timestamp]);
         $localCategoryId = $this->manager->getConnection()->fetchColumn('SELECT LAST_INSERT_ID()');
 
         $this->manager->getConnection()->executeQuery('INSERT INTO `s_categories_attributes` (`categoryID`, `connect_imported_category`) 


### PR DESCRIPTION
before we don't fill the Timestamp Columns `added` and `changed`
if we create a local category from an remote category.
This made problems with the generated sitemap for google.
Now these columns get filled with the current Datetime.