### PR TITLE
CON-4955: ArticleSubscriber uses right FetchMode

### DIFF
--- a/Subscribers/Article.php
+++ b/Subscribers/Article.php
@@ -230,10 +230,10 @@ class Article implements SubscriberInterface
                     $this->modelManager->flush();
                 }
 
-                $sourceIds = $this->modelManager->getConnection()->fetchColumn(
+                $sourceIds = $this->modelManager->getConnection()->executeQuery(
                     'SELECT source_id FROM s_plugin_connect_items WHERE article_id = ?',
                     [$article->getId()]
-                );
+                )->fetchAll(\PDO::FETCH_COLUMN);
 
                 $this->connectExport->export($sourceIds);
                 break;

--- a/Subscribers/Article.php
+++ b/Subscribers/Article.php
@@ -235,7 +235,16 @@ class Article implements SubscriberInterface
                     [$article->getId()]
                 )->fetchAll(\PDO::FETCH_COLUMN);
 
-                $this->connectExport->export($sourceIds);
+                $autoUpdateProducts = $this->config->getConfig('autoUpdateProducts');
+                if ($autoUpdateProducts == Config::UPDATE_CRON_JOB) {
+                    $this->modelManager->getConnection()->update(
+                        's_plugin_connect_items',
+                        ['cron_update' => 1],
+                        ['article_id' => $article->getId()]
+                    );
+                } else {
+                    $this->connectExport->export($sourceIds);
+                }
                 break;
             case 'createConfiguratorVariants':
                 // main detail should be updated as well, because shopware won't call lifecycle event

--- a/Subscribers/Article.php
+++ b/Subscribers/Article.php
@@ -230,11 +230,6 @@ class Article implements SubscriberInterface
                     $this->modelManager->flush();
                 }
 
-                $sourceIds = $this->modelManager->getConnection()->executeQuery(
-                    'SELECT source_id FROM s_plugin_connect_items WHERE article_id = ?',
-                    [$article->getId()]
-                )->fetchAll(\PDO::FETCH_COLUMN);
-
                 $autoUpdateProducts = $this->config->getConfig('autoUpdateProducts');
                 if ($autoUpdateProducts == Config::UPDATE_CRON_JOB) {
                     $this->modelManager->getConnection()->update(
@@ -243,6 +238,10 @@ class Article implements SubscriberInterface
                         ['article_id' => $article->getId()]
                     );
                 } else {
+                    $sourceIds = $this->modelManager->getConnection()->executeQuery(
+                        'SELECT source_id FROM s_plugin_connect_items WHERE article_id = ?',
+                        [$article->getId()]
+                    )->fetchAll(\PDO::FETCH_COLUMN);
                     $this->connectExport->export($sourceIds);
                 }
                 break;

--- a/Tests/Functional/Subscribers/ArticleTest.php
+++ b/Tests/Functional/Subscribers/ArticleTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ShopwarePlugins\Connect\Tests\Functional\Subscriber;
+
+use ShopwarePlugins\Connect\Tests\DatabaseTestCaseTrait;
+
+class ArticleTest extends \Enlight_Components_Test_Plugin_TestCase
+{
+    use DatabaseTestCaseTrait;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // disable auth and acl
+        Shopware()->Plugins()->Backend()->Auth()->setNoAuth();
+        Shopware()->Plugins()->Backend()->Auth()->setNoAcl();
+
+        $this->manager = Shopware()->Models();
+    }
+
+    public function testExtendBackendArticlePropertyGroup()
+    {
+        $this->importFixtures(__DIR__ . '/_fixtures/articleWithPriceGroup.sql');
+
+        $this->Request()
+            ->setMethod('POST')
+            ->setPost('articleId', '32870');
+        $this->dispatch('backend/Article/setPropertyList');
+
+        self::assertEquals(200, $this->Response()->getHttpResponseCode());
+        self::assertTrue($this->View()->success);
+
+        $statuses = $this->manager->getConnection()->executeQuery(
+            'SELECT export_status FROM s_plugin_connect_items WHERE article_id = ?',
+            [32870]
+        )->fetchAll(\PDO::FETCH_COLUMN);
+
+        foreach ($statuses as $status) {
+            //doesn't matter that theres an error
+            //but this verifys that the export of the articles has run
+            //we had an bug there: https://jira.shopware.com/browse/CON-4955
+            self::assertEquals('error', $status);
+        }
+    }
+}

--- a/Tests/Functional/Subscribers/_fixtures/articleWithPriceGroup.sql
+++ b/Tests/Functional/Subscribers/_fixtures/articleWithPriceGroup.sql
@@ -1,0 +1,18 @@
+INSERT INTO s_filter (`id`, `name`, `position`, `comparable`, `sortmode`) VALUES (1234, "TestFilter", 0, 1, 0);
+
+INSERT INTO s_articles (`id`, `name`, `main_detail_id`, filtergroupID, taxID) VALUES (32870, 'All-New Fire HD 8 Tablet', 2404535, 1234, 1);
+INSERT INTO s_articles_details (id, `articleID`, `ordernumber`, `kind`) VALUES (2404535, 32870, 'sw32870', 1);
+INSERT INTO s_articles_attributes (`articleID`, `articledetailsID`) VALUES (32870, 2404535);
+INSERT INTO s_plugin_connect_items (article_id, article_detail_id, source_id, exported, export_status)
+VALUES (32870, 2404535, 32870, 1, 'synced');
+
+INSERT INTO s_articles_details (id, `articleID`, `ordernumber`, `kind`) VALUES (2404536, 32870, 'sw32870.2', 2);
+INSERT INTO s_articles_attributes (`articleID`, `articledetailsID`) VALUES (32870, 2404536);
+INSERT INTO s_plugin_connect_items (article_id, article_detail_id, source_id, exported, export_status)
+VALUES (32870, 2404536, 32870, 1, 'synced');
+
+INSERT INTO s_articles_details (id, `articleID`, `ordernumber`, `kind`) VALUES (2404537, 32870, 'sw32870.3', 2);
+INSERT INTO s_articles_attributes (`articleID`, `articledetailsID`) VALUES (32870, 2404537);
+INSERT INTO s_plugin_connect_items (article_id, article_detail_id, source_id, exported, export_status)
+VALUES (32870, 2404537, 32870, 1, 'synced');
+


### PR DESCRIPTION
before the ArticleSubscriber used ->fetchColumn
that returns the result of the first row as string
after that we called export() with that
result
but exports() expects an array as input
with executeQuery()->fetchAll(\PDO::FETCH_COLUMN)
this query will return an array of articleIds