### PR TITLE
NTR: fixed mark Products in deleted Categories

### DIFF
--- a/Components/ConnectExport.php
+++ b/Components/ConnectExport.php
@@ -700,7 +700,10 @@ class ConnectExport
                     ->where('articleCategories.categoryID = (:categoryID)')
                     ->setParameter('categoryID', $categoryToBeDeleted);
                 $articlesInCategory = $builder->execute()->fetchAll(\PDO::FETCH_COLUMN);
-                $articlesInDeletedCategories = array_unique(array_merge($articlesInDeletedCategories, $articlesInCategory));
+                foreach ($articlesInCategory as $articleId) {
+                    //trick to get just unique articleIDs -> should be faster than array_unique(array_merge())
+                    $articlesInDeletedCategories[$articleId] = true;
+                }
             }
 
             //we can't export Products directly because Categories are still there
@@ -711,7 +714,7 @@ class ConnectExport
                     ->set('connectItems.cron_update', 1)
                     ->where('connectItems.article_id IN (:articleIDs)')
                     ->andWhere('connectItems.exported = 1')
-                    ->setParameter('articleIDs', $articlesInDeletedCategories, \Doctrine\DBAL\Connection::PARAM_STR_ARRAY);
+                    ->setParameter('articleIDs', array_keys($articlesInDeletedCategories), \Doctrine\DBAL\Connection::PARAM_STR_ARRAY);
 
                 $builder->execute();
             }


### PR DESCRIPTION
Currently this makes problems in b4a shop with deleting a
category with many childs and many products
after this change articleIds should be fetched "in batches"
per category
this could still make problems because b4a assigns all
products to every parent category
IMHO we can only really test this in production :(