### PR TITLE
CON-4969: fixed category assignment for categories with one article

### DIFF
--- a/Components/CategoryResolver.php
+++ b/Components/CategoryResolver.php
@@ -134,7 +134,7 @@ abstract class CategoryResolver
         $currentProductCategoryIds = $this->productToRemoteCategoryRepository->getRemoteCategoryIds($articleId);
 
         $assignedCategoryIds = array_map(function (RemoteCategory $assignedCategory) {
-            $assignedCategory->getId();
+            return $assignedCategory->getId();
         }, $assignedCategories);
 
         /** @var int $currentProductCategoryId */
@@ -195,7 +195,6 @@ abstract class CategoryResolver
             'SELECT connect_imported_category FROM s_categories_attributes WHERE categoryID = ?',
             [$categoryId]
         );
-
         if ($connectImported == 1 && $this->countChildCategories($categoryId) === 0) {
             $parent = (int) $this->manager->getConnection()->fetchColumn(
                 'SELECT parent FROM s_categories WHERE `id` = ?',

--- a/Tests/Integration/Components/ProductToShopTest.php
+++ b/Tests/Integration/Components/ProductToShopTest.php
@@ -681,4 +681,57 @@ class ProductToShopTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($existing, $actualTaxId);
     }
+    public function test_update_product_dont_delete_category_with_count_1()
+    {
+        $this->importFixtures(__DIR__ . '/_fixtures/connect_item_with_two_categories.sql');
+
+        $categoryAssignment = $this->manager->getConnection()->fetchColumn('SELECT * FROM `s_articles_categories` WHERE articleID = ? AND categoryID = ?',
+            [1234, 3333]
+        );
+        $this->assertNotFalse($categoryAssignment);
+
+        $product = $this->getProduct();
+        $product->shopId = 1234;
+        $product->sourceId = '1234-1';
+        $product->categories = [
+            '/deutsch' => 'Deutsch',
+            '/deutsch/test1' => 'Test 1'
+        ];
+
+        $this->productToShop->insertOrUpdate($product);
+
+        $articleCount = $this->manager->getConnection()->fetchColumn(
+            'SELECT COUNT(id) FROM s_articles WHERE id = ?',
+            [1234]
+        );
+        $this->assertEquals(1, $articleCount);
+
+        $categoryAssignment = $this->manager->getConnection()->fetchColumn('SELECT * FROM `s_articles_categories` WHERE articleID = ? AND categoryID = ?',
+            [1234, 4444]
+        );
+        $this->assertFalse($categoryAssignment);
+
+        $categoryAssignment = $this->manager->getConnection()->fetchColumn('SELECT * FROM `s_articles_categories` WHERE articleID = ? AND categoryID = ?',
+            [1234, 2222]
+        );
+        $this->assertFalse($categoryAssignment);
+
+        $categoryAssignment = $this->manager->getConnection()->fetchColumn('SELECT * FROM `s_articles_categories` WHERE articleID = ? AND categoryID = ?',
+            [1234, 3333]
+        );
+        $this->assertNotFalse($categoryAssignment);
+
+        $localCategory = $this->manager->getConnection()->fetchColumn('SELECT * FROM `s_categories` WHERE id = ?',
+            [4444]
+        );
+        $this->assertFalse($localCategory);
+        $localCategory = $this->manager->getConnection()->fetchColumn('SELECT * FROM `s_categories` WHERE id = ?',
+            [2222]
+        );
+        $this->assertNotFalse($localCategory);
+        $localCategory = $this->manager->getConnection()->fetchColumn('SELECT * FROM `s_categories` WHERE id = ?',
+            [3333]
+        );
+        $this->assertNotFalse($localCategory);
+    }
 }

--- a/Tests/Integration/Components/_fixtures/connect_item_with_two_categories.sql
+++ b/Tests/Integration/Components/_fixtures/connect_item_with_two_categories.sql
@@ -1,0 +1,31 @@
+INSERT INTO s_articles (`id`, `name`, main_detail_id, changetime, pricegroupActive, laststock, crossbundlelook, notification, template, mode)
+VALUES (1234, 'Baby-Träger', 7091846, NOW(), 1, 1, 0, 0, 1, 0);
+INSERT INTO s_articles_details (id, `articleID`, `ordernumber`, `kind`, `position`) VALUES (7091846, 1234, 'sw1004', 1, 0);
+INSERT INTO s_plugin_connect_items (article_id, article_detail_id, source_id, purchase_price_hash, offer_valid_until, stream, shop_id)
+VALUES (1234, 7091846, "1234-1", "hash", 123, 1, 1234);
+
+INSERT INTO s_categories (id, parent, description, `left`, `right`, `level`, added, changed, active, blog, hidefilter, hidetop)
+VALUES (2222, 1, "Deutsch", 1, 1, 1, NOW(), NOW(), 1, 1, 0, 0);
+INSERT INTO s_categories (id, parent, description, `left`, `right`, `level`, added, changed, active, blog, hidefilter, hidetop)
+VALUES (3333, 2222, "Deutsch", 1, 1, 1, NOW(), NOW(), 1, 1, 0, 0);
+INSERT INTO s_categories (id, parent, description, `left`, `right`, `level`, added, changed, active, blog, hidefilter, hidetop)
+VALUES (4444, 2222, "Deutsch", 1, 1, 1, NOW(), NOW(), 1, 1, 0, 0);
+
+INSERT INTO s_articles_categories (articleID, categoryID) VALUES (1234, 3333);
+INSERT INTO s_articles_categories (articleID, categoryID) VALUES (1234, 4444);
+
+INSERT INTO s_plugin_connect_categories (id, category_key, label, shop_id) VALUES (2222, "/deutsch", "Deutsch", 1234);
+INSERT INTO s_plugin_connect_categories (id, category_key, label, shop_id) VALUES (3333, "/deutsch/test1", "Test 1", 1234);
+INSERT INTO s_plugin_connect_categories (id, category_key, label, shop_id) VALUES (4444, "/deutsch/test2", "Test 2", 1234);
+
+INSERT INTO s_plugin_connect_product_to_categories (connect_category_id, articleID) VALUES (2222, 1234);
+INSERT INTO s_plugin_connect_product_to_categories (connect_category_id, articleID) VALUES (3333, 1234);
+INSERT INTO s_plugin_connect_product_to_categories (connect_category_id, articleID) VALUES (4444, 1234);
+
+INSERT INTO s_plugin_connect_categories_to_local_categories (remote_category_id, local_category_id) VALUES (2222, 2222);
+INSERT INTO s_plugin_connect_categories_to_local_categories (remote_category_id, local_category_id) VALUES (3333, 3333);
+INSERT INTO s_plugin_connect_categories_to_local_categories (remote_category_id, local_category_id) VALUES (4444, 4444);
+
+INSERT INTO s_categories_attributes (categoryID, connect_imported_category) VALUES (2222, 1);
+INSERT INTO s_categories_attributes (categoryID, connect_imported_category) VALUES (3333, 1);
+INSERT INTO s_categories_attributes (categoryID, connect_imported_category) VALUES (4444, 1);


### PR DESCRIPTION
Before local categories with only one article get deleted if these
article receives change, because we remove all assigned connect
categories in the beginning of ProductToShop::insertOrUpdate()
now this is handled properly in CategoryResolver::storeRemoteCategories
Another problem was that we assigned parent categories to all articles
this is right for b4a but could make problems for everybody else
now the parent category gets deleted if we assign a new category
this works also for b4a because they want the posibillity to assign
articles to not leaf categories