### PR TITLE
NTR: check if configuratorSet is empty

### DIFF
--- a/Components/VariantConfigurator.php
+++ b/Components/VariantConfigurator.php
@@ -47,7 +47,7 @@ class VariantConfigurator
      */
     public function configureVariantAttributes(Product $product, Detail $detail)
     {
-        if (count($product->variant) === 0 || $product->configuratorSetType === null) {
+        if (count($product->variant) === 0) {
             return;
         }
 
@@ -57,12 +57,14 @@ class VariantConfigurator
             $configSet = new Set();
             $configSet->setName('Set-' . $article->getName());
             $configSet->setArticles([$article]);
+            $configSet->setType(0);
             $article->setConfiguratorSet($configSet);
         } else {
             $configSet = $article->getConfiguratorSet();
         }
-
-        $configSet->setType($product->configuratorSetType);
+        if ($product->configuratorSetType !== null) {   
+            $configSet->setType($product->configuratorSetType);
+        }
 
         foreach ($product->variant as $key => $value) {
             $group = $this->getGroupByName($configSet, $key);

--- a/Components/VariantConfigurator.php
+++ b/Components/VariantConfigurator.php
@@ -47,7 +47,7 @@ class VariantConfigurator
      */
     public function configureVariantAttributes(Product $product, Detail $detail)
     {
-        if (count($product->variant) === 0) {
+        if (count($product->variant) === 0 || $product->configuratorSetType === null) {
             return;
         }
 


### PR DESCRIPTION
this has thrown exceptions on staging
i guess this could also happen if supplier has old plugin version and
merchant newer