### PR TITLE
CON-4973: subcategories in default category resolver are created

### DIFF
--- a/Components/CategoryResolver.php
+++ b/Components/CategoryResolver.php
@@ -80,17 +80,9 @@ abstract class CategoryResolver
         $tree = [];
 
         if (strlen($idPrefix) > 0) {
-            // find child categories by given prefix
-            $childCategories = array_filter(array_keys($categories), function ($key) use ($idPrefix) {
-                return strpos($key, $idPrefix) === 0 && strrpos($key, '/') === strlen($idPrefix);
-            });
-            $filteredCategories = array_intersect_key($categories, array_flip($childCategories));
+            $filteredCategories = $this->findChildCategories($categories, $idPrefix);
         } else {
-            // filter only main categories
-            $matchedKeys = array_filter(array_keys($categories), function ($key) {
-                return strrpos($key, '/') === 0;
-            });
-            $filteredCategories = array_intersect_key($categories, array_flip($matchedKeys));
+            $filteredCategories = $this->filterMainCategories($categories);
         }
 
         foreach ($filteredCategories as $key => $categoryName) {
@@ -360,5 +352,34 @@ abstract class CategoryResolver
             'SELECT COUNT(id) FROM s_categories WHERE parent = ?',
             [$categoryId]
         );
+    }
+
+    /**
+     * @param array $categories
+     * @param $idPrefix
+     * @return array
+     */
+    private function findChildCategories(array $categories, $idPrefix)
+    {
+        $childCategories = array_filter(array_keys($categories), function ($key) use ($idPrefix) {
+            return strpos($key, $idPrefix) === 0 && strrpos($key, '/') === strlen($idPrefix);
+        });
+        $filteredCategories = array_intersect_key($categories, array_flip($childCategories));
+
+        return $filteredCategories;
+    }
+
+    /**
+     * @param array $categories
+     * @return array
+     */
+    private function filterMainCategories(array $categories)
+    {
+        $matchedKeys = array_filter(array_keys($categories), function ($key) {
+            return strrpos($key, '/') === 0;
+        });
+        $filteredCategories = array_intersect_key($categories, array_flip($matchedKeys));
+
+        return $filteredCategories;
     }
 }

--- a/Components/CategoryResolver.php
+++ b/Components/CategoryResolver.php
@@ -16,6 +16,7 @@ use Shopware\Models\Category\Repository as CategoryRepository;
 use Shopware\Models\Category\Category;
 use Shopware\Components\Model\CategoryDenormalization;
 
+//ToDo Refactor this one
 abstract class CategoryResolver
 {
     /**

--- a/Components/CategoryResolver/AutoCategoryResolver.php
+++ b/Components/CategoryResolver/AutoCategoryResolver.php
@@ -87,38 +87,4 @@ class AutoCategoryResolver extends CategoryResolver
             return $category['categoryKey'];
         }, $remoteCategories);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function generateTree(array $categories, $idPrefix = '')
-    {
-        $tree = [];
-
-        if (strlen($idPrefix) > 0) {
-            // find child categories by given prefix
-            $childCategories = array_filter(array_keys($categories), function ($key) use ($idPrefix) {
-                return strpos($key, $idPrefix) === 0 && strrpos($key, '/') === strlen($idPrefix);
-            });
-            $filteredCategories = array_intersect_key($categories, array_flip($childCategories));
-        } else {
-            // filter only main categories
-            $matchedKeys = array_filter(array_keys($categories), function ($key) {
-                return strrpos($key, '/') === 0;
-            });
-            $filteredCategories = array_intersect_key($categories, array_flip($matchedKeys));
-        }
-
-        foreach ($filteredCategories as $key => $categoryName) {
-            $children = $this->generateTree($categories, $key);
-            $tree[$key] = [
-                'name' => $categoryName,
-                'children' => $children,
-                'categoryId' => $key,
-                'leaf' => empty($children),
-            ];
-        }
-
-        return $tree;
-    }
 }

--- a/Components/CategoryResolver/DefaultCategoryResolver.php
+++ b/Components/CategoryResolver/DefaultCategoryResolver.php
@@ -48,13 +48,19 @@ class DefaultCategoryResolver extends CategoryResolver
      */
     private function getDirectlyAssignedCategories($remoteCategoryId, $shopId, $stream)
     {
-        return (array) $this->manager->getConnection()->executeQuery('
+        $localCategories = $this->manager->getConnection()->executeQuery('
               SELECT pclc.local_category_id
               FROM s_plugin_connect_categories_to_local_categories AS pclc
               INNER JOIN s_plugin_connect_categories AS pcc ON pcc.id = pclc.remote_category_id
               WHERE pcc.category_key = ? AND pcc.shop_id = ? AND (pclc.stream = ? OR pclc.stream IS NULL) ',
             [$remoteCategoryId, $shopId, $stream]
         )->fetchAll(\PDO::FETCH_COLUMN);
+
+        if ($localCategories === false) {
+            return [];
+        } else {
+            return $localCategories;
+        }
     }
 
     /**

--- a/Components/CategoryResolver/DefaultCategoryResolver.php
+++ b/Components/CategoryResolver/DefaultCategoryResolver.php
@@ -18,7 +18,7 @@ class DefaultCategoryResolver extends CategoryResolver
     {
         $tree = $this->generateTree($categories);
 
-        return array_keys($this->traverseTree($tree, $shopId, $stream));
+        return array_keys($this->findAssignedLocalCategories($tree, $shopId, $stream));
     }
 
     /**
@@ -27,7 +27,7 @@ class DefaultCategoryResolver extends CategoryResolver
      * @param string $stream
      * @return array
      */
-    private function traverseTree(array $children, $shopId, $stream)
+    private function findAssignedLocalCategories(array $children, $shopId, $stream)
     {
         $childCategories = [];
         $mappedCategories = [];
@@ -40,7 +40,7 @@ class DefaultCategoryResolver extends CategoryResolver
               [$category['categoryId'], $shopId, $stream]
             )->fetchAll(\PDO::FETCH_COLUMN);
 
-            if ($localCategories) {
+            if (is_array($localCategories)) {
                 foreach ($localCategories as $localCategory) {
                     $mappedCategories[$localCategory] = true;
                     if (!empty($category['children'])) {
@@ -53,7 +53,7 @@ class DefaultCategoryResolver extends CategoryResolver
 
             if (!empty($category['children'])) {
                 //use + not array_merge because we want to preserve the numeric keys
-                $childCategories = $childCategories + $this->traverseTree($category['children'], $shopId, $stream);
+                $childCategories = $childCategories + $this->findAssignedLocalCategories($category['children'], $shopId, $stream);
             }
         }
 

--- a/Components/CategoryResolver/DefaultCategoryResolver.php
+++ b/Components/CategoryResolver/DefaultCategoryResolver.php
@@ -32,7 +32,7 @@ class DefaultCategoryResolver extends CategoryResolver
         $childCategories = [];
         $mappedCategories = [];
         foreach ($children as $category) {
-            $localCategories = $this->manager->getConnection()->executeQuery('
+            $localCategories = (array) $this->manager->getConnection()->executeQuery('
               SELECT pclc.local_category_id
               FROM s_plugin_connect_categories_to_local_categories AS pclc
               INNER JOIN s_plugin_connect_categories AS pcc ON pcc.id = pclc.remote_category_id
@@ -40,13 +40,11 @@ class DefaultCategoryResolver extends CategoryResolver
               [$category['categoryId'], $shopId, $stream]
             )->fetchAll(\PDO::FETCH_COLUMN);
 
-            if (is_array($localCategories)) {
-                foreach ($localCategories as $localCategory) {
-                    $mappedCategories[$localCategory] = true;
-                    if (!empty($category['children'])) {
-                        foreach ($this->convertTreeToKeys($category['children'], $localCategory, $shopId, $stream) as $local) {
-                            $mappedCategories[$local['categoryKey']] = true;
-                        }
+            foreach ($localCategories as $localCategory) {
+                $mappedCategories[$localCategory] = true;
+                if (count($category['children']) > 0) {
+                    foreach ($this->convertTreeToKeys($category['children'], $localCategory, $shopId, $stream) as $local) {
+                        $mappedCategories[$local['categoryKey']] = true;
                     }
                 }
             }

--- a/Tests/Integration/Components/CategoryResolver/DefaultCategoryResolverTest.php
+++ b/Tests/Integration/Components/CategoryResolver/DefaultCategoryResolverTest.php
@@ -53,7 +53,7 @@ class DefaultCategoryResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([2222, 3333, 4444], $localCategories);
     }
 
-    public function testResolveReturnsNotAll()
+    public function testResolveReturnsAllWithAddingAssignmentOfStream()
     {
         $this->manager->getConnection()->executeQuery('DELETE FROM s_categories');
         $this->manager->getConnection()->executeQuery('DELETE FROM s_plugin_connect_categories');
@@ -67,6 +67,77 @@ class DefaultCategoryResolverTest extends \PHPUnit_Framework_TestCase
 
         $localCategories = $this->categoryResolver->resolve($categories, 1234, 'AwesomeTest');
 
-        $this->assertEquals([2222, 3333], $localCategories);
+        $this->assertEquals([2222, 3333, 4444], $localCategories);
+
+        $streamAssignment = $this->manager->getConnection()->fetchColumn('SELECT id FROM s_plugin_connect_categories_to_local_categories WHERE local_category_id = 4444 AND remote_category_id = 4444 AND stream = "AwesomeTest"');
+        $this->assertNotFalse($streamAssignment);
+    }
+
+    public function testResolveCreatesChildCategories()
+    {
+        $this->manager->getConnection()->executeQuery('DELETE FROM s_categories');
+        $this->manager->getConnection()->executeQuery('DELETE FROM s_plugin_connect_categories');
+        $this->manager->getConnection()->executeQuery('DELETE FROM s_plugin_connect_categories_to_local_categories');
+        $this->importFixtures(__DIR__ . '/../_fixtures/one_connect_to_local_category.sql');
+        $categories = [
+            '/deutsch' => 'Deutsch',
+            '/deutsch/test1' => 'Test 1',
+            '/deutsch/test2' => 'Test 2'
+        ];
+
+        $localCategories = $this->categoryResolver->resolve($categories, 1234, 'Teststream');
+
+        $this->assertArraySubset([2222], $localCategories);
+        $this->assertCount(3, $localCategories);
+        $mappedRemoteCategories = [];
+        foreach ($localCategories as $localCategory) {
+            $categoryAssignment = $this->manager->getConnection()->fetchColumn('
+            SELECT pc.id
+            FROM s_categories AS sc
+            INNER JOIN s_categories_attributes AS sca ON sc.id = sca.categoryID
+            INNER JOIN s_plugin_connect_categories_to_local_categories AS pclc ON pclc.local_category_id = sc.id
+            INNER JOIN s_plugin_connect_categories AS pc ON pc.id = pclc.remote_category_id
+            WHERE sc.id = ? AND sca.connect_imported_category = 1 AND pclc.stream = "Teststream" AND pc.id IN (2222, 3333, 4444)', [$localCategory]);
+            $this->assertNotFalse($categoryAssignment);
+            $mappedRemoteCategories[] = $categoryAssignment;
+
+            $streamAssignment = $this->manager->getConnection()->fetchColumn('SELECT id FROM s_plugin_connect_categories_to_local_categories WHERE local_category_id = ? AND remote_category_id IN (2222, 3333, 4444) AND stream = "Teststream"', [$localCategory]);
+            $this->assertNotFalse($streamAssignment);
+        }
+        $this->assertEquals([2222,3333,4444], $mappedRemoteCategories);
+    }
+
+    public function testResolveReturnsNothingWithWrongStream()
+    {
+        $this->manager->getConnection()->executeQuery('DELETE FROM s_categories');
+        $this->manager->getConnection()->executeQuery('DELETE FROM s_plugin_connect_categories');
+        $this->manager->getConnection()->executeQuery('DELETE FROM s_plugin_connect_categories_to_local_categories');
+        $this->importFixtures(__DIR__ . '/../_fixtures/one_connect_to_local_category.sql');
+        $categories = [
+            '/deutsch' => 'Deutsch',
+            '/deutsch/test1' => 'Test 1',
+            '/deutsch/test2' => 'Test 2'
+        ];
+
+        $localCategories = $this->categoryResolver->resolve($categories, 1234, 'Awesome Stream Test');
+
+        $this->assertEmpty($localCategories);
+    }
+
+    public function testResolveReturnsNothingWithWrongShop()
+    {
+        $this->manager->getConnection()->executeQuery('DELETE FROM s_categories');
+        $this->manager->getConnection()->executeQuery('DELETE FROM s_plugin_connect_categories');
+        $this->manager->getConnection()->executeQuery('DELETE FROM s_plugin_connect_categories_to_local_categories');
+        $this->importFixtures(__DIR__ . '/../_fixtures/one_connect_to_local_category.sql');
+        $categories = [
+            '/deutsch' => 'Deutsch',
+            '/deutsch/test1' => 'Test 1',
+            '/deutsch/test2' => 'Test 2'
+        ];
+
+        $localCategories = $this->categoryResolver->resolve($categories, 1, 'Teststream');
+
+        $this->assertEmpty($localCategories);
     }
 }

--- a/Tests/Integration/Components/ProductToShopTest.php
+++ b/Tests/Integration/Components/ProductToShopTest.php
@@ -872,8 +872,12 @@ class ProductToShopTest extends \PHPUnit_Framework_TestCase
         $id = $this->manager->getConnection()->fetchColumn('SELECT id FROM s_articles_categories WHERE articleID = 1234 AND categoryID = 2222');
         $this->assertNotFalse($id);
 
-        //category in wrong stream
+        //category in wrong stream but child of assigned categories
         $id = $this->manager->getConnection()->fetchColumn('SELECT id FROM s_articles_categories WHERE articleID = 1234 AND categoryID = 3333');
+        $this->assertNotFalse($id);
+
+        //category in wrong stream
+        $id = $this->manager->getConnection()->fetchColumn('SELECT id FROM s_articles_categories WHERE articleID = 1234 AND categoryID = 4444');
         $this->assertFalse($id);
     }
 }

--- a/Tests/Integration/Components/_fixtures/categories.sql
+++ b/Tests/Integration/Components/_fixtures/categories.sql
@@ -5,9 +5,13 @@ INSERT INTO s_plugin_connect_categories (id, category_key, label, shop_id) VALUE
 INSERT INTO s_categories (id, parent, description, `left`, `right`, `level`, added, changed, active, blog, hidefilter, hidetop)
 VALUES (2222, 1, "Deutsch", 1, 1, 1, NOW(), NOW(), 1, 1, 0, 0);
 INSERT INTO s_categories (id, parent, description, `left`, `right`, `level`, added, changed, active, blog, hidefilter, hidetop)
-VALUES (3333, 2222, "Deutsch", 1, 1, 1, NOW(), NOW(), 1, 1, 0, 0);
+VALUES (3333, 2222, "Test 1", 1, 1, 1, NOW(), NOW(), 1, 1, 0, 0);
 INSERT INTO s_categories (id, parent, description, `left`, `right`, `level`, added, changed, active, blog, hidefilter, hidetop)
-VALUES (4444, 2222, "Deutsch", 1, 1, 1, NOW(), NOW(), 1, 1, 0, 0);
+VALUES (4444, 2222, "Test 2", 1, 1, 1, NOW(), NOW(), 1, 1, 0, 0);
+
+INSERT INTO s_categories_attributes (categoryID, connect_imported_category) VALUES (2222, 1);
+INSERT INTO s_categories_attributes (categoryID, connect_imported_category) VALUES (3333, 1);
+INSERT INTO s_categories_attributes (categoryID, connect_imported_category) VALUES (4444, 1);
 
 INSERT INTO s_plugin_connect_categories_to_local_categories (remote_category_id, local_category_id, stream) VALUES (2222, 2222, NULL);
 INSERT INTO s_plugin_connect_categories_to_local_categories (remote_category_id, local_category_id, stream) VALUES (3333, 3333, "Teststream");

--- a/Tests/Integration/Components/_fixtures/one_connect_to_local_category.sql
+++ b/Tests/Integration/Components/_fixtures/one_connect_to_local_category.sql
@@ -1,0 +1,10 @@
+INSERT INTO s_plugin_connect_categories (id, category_key, label, shop_id) VALUES (2222, "/deutsch", "Deutsch", 1234);
+INSERT INTO s_plugin_connect_categories (id, category_key, label, shop_id) VALUES (3333, "/deutsch/test1", "Test 1", 1234);
+INSERT INTO s_plugin_connect_categories (id, category_key, label, shop_id) VALUES (4444, "/deutsch/test2", "Test 2", 1234);
+
+INSERT INTO s_categories (id, parent, description, `left`, `right`, `level`, added, changed, active, blog, hidefilter, hidetop)
+VALUES (2222, 1, "Deutsch", 1, 1, 1, NOW(), NOW(), 1, 1, 0, 0);
+
+INSERT INTO s_categories_attributes (categoryID, connect_imported_category) VALUES (2222, 1);
+
+INSERT INTO s_plugin_connect_categories_to_local_categories (remote_category_id, local_category_id, stream) VALUES (2222, 2222, "Teststream");

--- a/Tests/Integration/Components/_fixtures/one_item_category_with_wrong_stream.sql
+++ b/Tests/Integration/Components/_fixtures/one_item_category_with_wrong_stream.sql
@@ -21,3 +21,9 @@ INSERT INTO `s_plugin_connect_product_to_categories` (`articleID`, `connect_cate
 INSERT INTO s_categories (id, parent, path, description) VALUES (3333, 1111 ,"|3|1111|", "Romane");
 INSERT INTO s_categories_attributes (categoryID, connect_imported_category) VALUES (3333, 1);
 INSERT INTO s_plugin_connect_categories_to_local_categories (remote_category_id, local_category_id, stream) VALUES (3333, 3333, "Test stream");
+
+INSERT INTO s_plugin_connect_categories (id, category_key, label, shop_id) VALUES (4444, "/deutsch/schuhe", "Schuhe", 1234);
+INSERT INTO `s_plugin_connect_product_to_categories` (`articleID`, `connect_category_id`) VALUES (1234, 4444);
+INSERT INTO s_categories (id, parent, path, description) VALUES (4444, 3 ,"|3|", "Schuhe");
+INSERT INTO s_categories_attributes (categoryID, connect_imported_category) VALUES (4444, 1);
+INSERT INTO s_plugin_connect_categories_to_local_categories (remote_category_id, local_category_id, stream) VALUES (4444, 4444, "Test stream");

--- a/Tests/Unit/Models/RemoteCategoryTest.php
+++ b/Tests/Unit/Models/RemoteCategoryTest.php
@@ -9,7 +9,6 @@ namespace ShopwarePlugins\Connect\Tests\Unit\Components;
 
 use Shopware\CustomModels\Connect\RemoteCategory;
 use Shopware\CustomModels\Connect\RemoteToLocalCategory;
-use Shopware\Models\Category\Category;
 
 class RemoteCategoryTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
before we don't create new subcategories if the parent connect category
is assigned
now it is checked that all subcategories of each assigned remote
category are there and if not they are created