### PR TITLE
CON-4978: fixed count for connect items in export window

### DIFF
--- a/Components/ConnectExport.php
+++ b/Components/ConnectExport.php
@@ -499,8 +499,8 @@ class ConnectExport
             'i.cron_update as cronUpdate'
         ])
             ->from('s_plugin_connect_items', 'i')
-            ->innerJoin('i', 's_articles', 'a', 'a.id = i.article_id')
-            ->innerJoin('a', 's_articles_details', 'd', 'a.main_detail_id = d.id')
+            ->leftJoin('i', 's_articles', 'a', 'a.id = i.article_id')
+            ->leftJoin('a', 's_articles_details', 'd', 'a.main_detail_id = d.id')
             ->leftJoin('d', 's_articles_prices', 'p', 'd.id = p.articledetailsID')
             ->leftJoin('a', 's_core_tax', 't', 'a.taxID = t.id')
             ->leftJoin('a', 's_articles_supplier', 's', 'a.supplierID = s.id')

--- a/Components/ConnectExport.php
+++ b/Components/ConnectExport.php
@@ -568,12 +568,14 @@ class ConnectExport
             $builder->orderBy($criteria->orderBy, $criteria->orderByDirection);
         }
 
-        $total = $builder->execute()->rowCount();
-
         $builder->setFirstResult($criteria->offset);
         $builder->setMaxResults($criteria->limit);
 
         $data = $builder->execute()->fetchAll();
+
+        $total = $this->manager->getConnection()->fetchColumn(
+            'SELECT COUNT(DISTINCT article_id) FROM s_plugin_connect_items WHERE shop_id IS NULL'
+        );
 
         return new ExportList([
             'articles' => $data,

--- a/Tests/Integration/Components/ConnectExportTest.php
+++ b/Tests/Integration/Components/ConnectExportTest.php
@@ -12,6 +12,7 @@ use ShopwarePlugins\Connect\Components\ConfigFactory;
 use ShopwarePlugins\Connect\Components\ConnectExport;
 use ShopwarePlugins\Connect\Components\ErrorHandler;
 use ShopwarePlugins\Connect\Components\Validator\ProductAttributesValidator\ProductsAttributesValidator;
+use ShopwarePlugins\Connect\Struct\SearchCriteria;
 use ShopwarePlugins\Connect\Tests\ConnectTestHelperTrait;
 use ShopwarePlugins\Connect\Tests\DatabaseTestCaseTrait;
 use Shopware\Models\Category\Category;
@@ -84,5 +85,22 @@ class ConnectExportTest extends \PHPUnit_Framework_TestCase
 
         $count = $this->manager->getConnection()->executeQuery('SELECT COUNT(*) FROM `s_plugin_connect_items` WHERE `cron_update` = 1')->fetchColumn();
         $this->assertEquals(0, (int) $count);
+    }
+
+    public function testGetExportList()
+    {
+        $this->manager->getConnection()->executeQuery('DELETE FROM `s_plugin_connect_items`');
+        $this->importFixtures(__DIR__ . '/../_fixtures/simple_connect_items.sql');
+
+        $criteria = new SearchCriteria();
+        $criteria->limit = 20;
+        $criteria->offset = 0;
+
+        $result = $this->connectExport->getExportList($criteria);
+
+        $this->assertCount(5, $result->articles);
+        $this->assertEquals(14467, $result->articles[0]['id']);
+        $this->assertEquals(14471, $result->articles[4]['id']);
+        $this->assertEquals(5, $result->count);
     }
 }


### PR DESCRIPTION
before we fired the whole query with 5 joins and get the rowCount
now we use a proper Count-Query
increases loading speed for ExportList from >30s to <300ms for 1M products