### PR TITLE
CON-5110 Add local shipping costs when necessary

### DIFF
--- a/Components/BasketHelper.php
+++ b/Components/BasketHelper.php
@@ -227,7 +227,7 @@ class BasketHelper
             $this->removeNonProductsFromBasket();
 
             $connectContent = $this->getConnectContent();
-            if (false === $this->customerHasToPayLocalShipping($connectContent)) {
+            if ($this->customerHasToPayLocalShipping($connectContent) === false) {
                 $this->basket = $this->removeDefaultShipping($this->basket);
             }
 


### PR DESCRIPTION
Add local shipping costs price even when basket contains only connect products.
This is needed when at least one supplier has shipping cost type = all or filter.
Then endcustomer has to pay merchant shipping costs and shipping costs provided by
other suppliers remotely.