### PR TITLE
CON-5114 Fixed preparation of Connect order during checkout

### DIFF
--- a/Subscribers/Checkout.php
+++ b/Subscribers/Checkout.php
@@ -209,14 +209,13 @@ class Checkout implements SubscriberInterface
 
             foreach ($this->basketHelper->getConnectProducts() as $shopId => $products) {
                 $products = $this->helper->prepareConnectUnit($products);
-                $allProducts = array_merge($allProducts, $products);
-                // add order items in connect order
-                $order->orderItems = array_map(function (Product $product) {
-                    return new OrderItem([
+                foreach ($products as $product) {
+                    $allProducts[] = $product;
+                    $order->orderItems[] = new OrderItem([
                         'product' => $product,
                         'count' => $this->basketHelper->getQuantityForProduct($product),
                     ]);
-                }, $products);
+                }
             }
 
             $this->eventManager->notify(


### PR DESCRIPTION
Some of the products are missing when there are more then 1 supplier
during checkout. Final all order will contain everything, but in confirm page
remote shipping is displayed only for the last supplier. This problem occurs,
because SDK order contains only products from last supplier when plugin makes
checkProducts call.