### PR TITLE
CON-5155: dynamic stream is exported with first CRON run

### DIFF
--- a/Components/ProductStream/ProductStreamService.php
+++ b/Components/ProductStream/ProductStreamService.php
@@ -28,6 +28,7 @@ class ProductStreamService
         self::STATUS_EXPORT,
         self::STATUS_SYNCED,
         self::STATUS_ERROR,
+        self::STATUS_PENDING,
     ];
 
     /**


### PR DESCRIPTION
problem was we checked each article if it is in an exported stream
when we create stream its status is 'pending'
pending wasn't in the exported statuses so articles
in this stream where not exported
in the end we set status of stream we created to 'exported'
in the next run the articles would be exported