### PR TITLE
ntr - find menu entry by class not by label

### DIFF
--- a/Services/MenuService.php
+++ b/Services/MenuService.php
@@ -50,7 +50,8 @@ class MenuService
         $plugin = $this->installerService->getPluginByName('SwagConnect');
 
         /** @var Menu $menuItem */
-        $menuItem = $this->manager->getRepository(Menu::class)->findOneBy(['label' => 'Connect']);
+        $menuItem = $this->manager->getRepository(Menu::class)
+            ->findOneBy(['class' => 'shopware-connect']);
 
         $this->connection->delete('s_core_menu', ['controller' => 'Connect', 'pluginID' => $plugin->getId()]);
         $this->connection->insert('s_core_menu', [


### PR DESCRIPTION
While resetting the exchange settings we reset the menu too by finding the top level menu entry by it's name.

If you're connected to a custom marketplace the label of the menu entry is changed to the marketplace's name and the MenuRepository will return null.