### PR TITLE
Ntr/improve export streams cron

### DIFF
--- a/Components/ProductStream/ProductSearch.php
+++ b/Components/ProductStream/ProductSearch.php
@@ -85,6 +85,14 @@ class ProductSearch
             new CategoryCondition([$context->getShop()->getCategory()->getId()])
         );
 
-        return $this->productSearchService->search($criteria, $context);
+        $result = $this->productSearchService->search($criteria, $context);
+
+        // elastic will fetch just 10 products by default -> so we fetch it again with correct limit
+        if ($result->getTotalCount() > count($result->getProducts())) {
+            $criteria->limit($result->getTotalCount());
+            $result = $this->productSearchService->search($criteria, $context);
+        }
+
+        return $result;
     }
 }

--- a/Components/ProductStream/ProductStreamService.php
+++ b/Components/ProductStream/ProductStreamService.php
@@ -86,6 +86,26 @@ class ProductStreamService
 
     /**
      * @param $streamId
+     * @param bool $appendCurrent
+     * @return ProductStreamsAssignments
+     */
+    public function getAssignmentsForStream($streamId)
+    {
+        $stream = $this->findStream($streamId);
+        $articleIds = $this->getArticlesIds($stream);
+        $assignment = [];
+
+        foreach ($articleIds as $articleId) {
+            $assignment[$articleId][$stream->getId()] = $stream->getName();
+        }
+
+        return new ProductStreamsAssignments(
+            ['assignments' => $assignment]
+        );
+    }
+
+    /**
+     * @param $streamId
      * @throws \Exception
      * @return ProductStreamsAssignments
      */

--- a/Components/ProductStream/ProductStreamsAssignments.php
+++ b/Components/ProductStream/ProductStreamsAssignments.php
@@ -14,7 +14,7 @@ class ProductStreamsAssignments extends Struct
     /**
      * @var array
      */
-    public $assignments;
+    public $assignments = [];
 
     /**
      * @param $articleId
@@ -51,5 +51,11 @@ class ProductStreamsAssignments extends Struct
         }
 
         return $articleIds;
+    }
+
+    public function merge(ProductStreamsAssignments $assignments) {
+        $this->assignments = $this->assignments + $assignments->assignments;
+
+        return $this;
     }
 }

--- a/Subscribers/CronJob.php
+++ b/Subscribers/CronJob.php
@@ -193,7 +193,7 @@ class CronJob implements SubscriberInterface
             }
 
             try {
-                $streamsAssignments->merge($this->productStreamService->prepareStreamsAssignments($streamId));
+                $streamsAssignments->merge($this->productStreamService->getAssignmentsForStream($streamId));
             } catch (\RuntimeException $e) {
                 $this->productStreamService->changeStatus($streamId, ProductStreamService::STATUS_ERROR, $e->getMessage());
                 continue;

--- a/Subscribers/CronJob.php
+++ b/Subscribers/CronJob.php
@@ -217,7 +217,12 @@ class CronJob implements SubscriberInterface
 
         $sourceIds = $this->helper->getArticleSourceIds($exportArticleIds);
 
-        $errorMessages = $this->connectExport->export($sourceIds, $streamsAssignments);
+        foreach (array_chunk($sourceIds, 100, true) as $ids) {
+            $errorMessages = $this->connectExport->export($ids, $streamsAssignments);
+            if ($errorMessages) {
+                break;
+            }
+        }
 
         if ($errorMessages) {
             $errorMessagesText = '';

--- a/Subscribers/CronJob.php
+++ b/Subscribers/CronJob.php
@@ -18,6 +18,7 @@ use ShopwarePlugins\Connect\Components\ImageImport;
 use ShopwarePlugins\Connect\Components\Logger;
 use ShopwarePlugins\Connect\Components\ConnectExport;
 use ShopwarePlugins\Connect\Components\ProductStream\ProductSearch;
+use ShopwarePlugins\Connect\Components\ProductStream\ProductStreamsAssignments;
 use ShopwarePlugins\Connect\Components\ProductStream\ProductStreamService;
 use Shopware\Components\DependencyInjection\Container;
 
@@ -172,6 +173,7 @@ class CronJob implements SubscriberInterface
     public function exportDynamicStreams(\Shopware_Components_Cron_CronJob $job)
     {
         $streams = $this->productStreamService->getAllExportedStreams(ProductStreamService::DYNAMIC_STREAM);
+        $streamsAssignments = new ProductStreamsAssignments();
 
         /** @var ProductStream $stream */
         foreach ($streams as $stream) {
@@ -191,42 +193,50 @@ class CronJob implements SubscriberInterface
             }
 
             try {
-                $streamsAssignments = $this->productStreamService->prepareStreamsAssignments($streamId, false);
-
-                //article ids must be taken from streamsAssignments
-                $exportArticleIds = $streamsAssignments->getArticleIds();
-
-                $removeArticleIds = $streamsAssignments->getArticleIdsWithoutStreams();
-
-                if (!empty($removeArticleIds)) {
-                    $this->removeArticlesFromStream($removeArticleIds);
-
-                    //filter the $exportArticleIds
-                    $exportArticleIds = array_diff($exportArticleIds, $removeArticleIds);
-                }
-
-                $sourceIds = $this->helper->getArticleSourceIds($exportArticleIds);
-
-                $errorMessages = $this->connectExport->export($sourceIds, $streamsAssignments);
-                $this->productStreamService->changeStatus($streamId, ProductStreamService::STATUS_EXPORT);
+                $streamsAssignments->merge($this->productStreamService->prepareStreamsAssignments($streamId));
             } catch (\RuntimeException $e) {
                 $this->productStreamService->changeStatus($streamId, ProductStreamService::STATUS_ERROR, $e->getMessage());
                 continue;
             }
+        }
+        if (count($streamsAssignments->assignments) === 0) {
+            return;
+        }
 
-            if ($errorMessages) {
-                $errorMessagesText = '';
-                $displayedErrorTypes = [
-                    ErrorHandler::TYPE_DEFAULT_ERROR,
-                    ErrorHandler::TYPE_PRICE_ERROR
-                ];
+        //article ids must be taken from streamsAssignments
+        $exportArticleIds = $streamsAssignments->getArticleIds();
 
-                foreach ($displayedErrorTypes as $displayedErrorType) {
-                    $errorMessagesText .= implode('\n', $errorMessages[$displayedErrorType]);
-                }
+        $removeArticleIds = $streamsAssignments->getArticleIdsWithoutStreams();
 
-                $this->productStreamService->changeStatus($streamId, ProductStreamService::STATUS_ERROR, $errorMessagesText);
+        if (!empty($removeArticleIds)) {
+            $this->removeArticlesFromStream($removeArticleIds);
+
+            //filter the $exportArticleIds
+            $exportArticleIds = array_diff($exportArticleIds, $removeArticleIds);
+        }
+
+        $sourceIds = $this->helper->getArticleSourceIds($exportArticleIds);
+
+        $errorMessages = $this->connectExport->export($sourceIds, $streamsAssignments);
+
+        if ($errorMessages) {
+            $errorMessagesText = '';
+            $displayedErrorTypes = [
+                ErrorHandler::TYPE_DEFAULT_ERROR,
+                ErrorHandler::TYPE_PRICE_ERROR
+            ];
+
+            foreach ($displayedErrorTypes as $displayedErrorType) {
+                $errorMessagesText .= implode('\n', $errorMessages[$displayedErrorType]);
             }
+
+            foreach ($streams as $stream) {
+                $this->productStreamService->changeStatus($stream->getId(), ProductStreamService::STATUS_ERROR, $errorMessagesText);
+            }
+        }
+
+        foreach ($streams as $stream) {
+            $this->productStreamService->changeStatus($stream->getId(), ProductStreamService::STATUS_EXPORT);
         }
     }
 

--- a/Tests/Unit/Subscribers/CronJobTest.php
+++ b/Tests/Unit/Subscribers/CronJobTest.php
@@ -106,7 +106,7 @@ class CronJobTest extends \PHPUnit_Framework_TestCase
         );
 
         $stream = $this->createMock(ProductStream::class);
-        $stream->expects($this->once())
+        $stream->expects($this->exactly(2))
             ->method('getId')
             ->willReturn(5);
 
@@ -149,7 +149,7 @@ class CronJobTest extends \PHPUnit_Framework_TestCase
         );
         $this->streamService->expects($this->once())
             ->method('prepareStreamsAssignments')
-            ->with(5, false)
+            ->with(5)
             ->willReturn($streamAssignments);
 
         $this->connectExport->expects($this->once())

--- a/Tests/Unit/Subscribers/CronJobTest.php
+++ b/Tests/Unit/Subscribers/CronJobTest.php
@@ -148,7 +148,7 @@ class CronJobTest extends \PHPUnit_Framework_TestCase
             ['assignments' => $assignment]
         );
         $this->streamService->expects($this->once())
-            ->method('prepareStreamsAssignments')
+            ->method('getAssignmentsForStream')
             ->with(5)
             ->willReturn($streamAssignments);
 


### PR DESCRIPTION
the cronJob now runs the ConnectExport just once for every product
and not for every Product and every Stream
this should improve the Performance in cases where the same
Products are in multiple streams